### PR TITLE
clean up dependencies for cell_census

### DIFF
--- a/api/python/cell_census/pyproject.toml
+++ b/api/python/cell_census/pyproject.toml
@@ -28,16 +28,16 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 dependencies= [
-    "numba>=0.55",
-    "numpy>=1.21",
-    "requests",
     # NOTE: the tiledbsoma version must be >= to the version used in the Census builder, to
     # ensure that the assets are readable (tiledbsoma supports backward compatible reading).
     # Make sure this version does not fall behind the builder's tiledbsoma version.
     "tiledbsoma==1.2.1",
+    "anndata",
+    "numpy>=1.21,<1.24",  # numpy is constrained by numba and the old pip solver
+    "requests",
     "typing_extensions",
     "s3fs",
-    "scikit-misc",
+    "scipy",
 ]
 
 [project.urls]


### PR DESCRIPTION
Fixes #336 

Changes to the dependencies for `cell-census` python package:
* remove unused/unnecessary packages (scikit-misc, numba)
* added missing package (scipy)
* changed order & constraints on numpy to allow the old pip solver to correctly determine version required