### PR TITLE
add old package name redirect

### DIFF
--- a/api/python/cell_census_pypi_redirect/README.md
+++ b/api/python/cell_census_pypi_redirect/README.md
@@ -1,0 +1,5 @@
+# cell-census is now cellxgene-census
+
+This package has been renamed. Use `pip install cellxgene-census` instead.
+
+New package: [https://pypi.org/project/cellxgene-census/](https://pypi.org/project/cellxgene-census/)

--- a/api/python/cell_census_pypi_redirect/pyproject.toml
+++ b/api/python/cell_census_pypi_redirect/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+
+[project]
+name = "cell_census"
+dynamic = ["version"]
+description = "cell-census is now cellxgene-census"
+readme = "README.md"
+authors = [
+    { name = "Chan Zuckerberg Initiative", email = "soma@chanzuckerberg.com" }
+]
+dependencies = [
+    "cellxgene-census"
+]
+classifiers = [
+    "Development Status :: 7 - Inactive",
+]
+
+[tool.setuptools_scm]
+root = "../../.."

--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -13,7 +13,7 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">= 3.7, < 3.11"  # Python 3.11 is pending numba support
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
Changes:
* add a new package, with old `cell-census` name, which depends on the new name
* bump current package metadata tag `Development Status` to `Alpha`
