### PR TITLE
Fix for Mac OSX certificate issue

### DIFF
--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -38,6 +38,8 @@ dependencies= [
     "typing_extensions",
     "s3fs",
     "scipy",
+    # Temporary fix for Mac OSX, to be removed by https://github.com/chanzuckerberg/cellxgene-census/issues/415
+    "certifi",
 ]
 
 [project.urls]

--- a/api/python/cellxgene_census/src/cellxgene_census/_open.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/_open.py
@@ -11,6 +11,7 @@ import os.path
 import urllib.parse
 from typing import Any, Dict, Optional
 
+import certifi
 import s3fs
 import tiledbsoma as soma
 
@@ -21,6 +22,8 @@ DEFAULT_TILEDB_CONFIGURATION: Dict[str, Any] = {
     # https://docs.tiledb.com/main/how-to/configuration#configuration-parameters
     "py.init_buffer_bytes": 1 * 1024**3,
     "soma.init_buffer_bytes": 1 * 1024**3,
+    # Temporary fix for Mac OSX, to be removed by https://github.com/chanzuckerberg/cellxgene-census/issues/415
+    "vfs.s3.ca_file": certifi.where(),
 }
 
 


### PR DESCRIPTION
Fixes #414 

Tested on Mac OSX 13.3.1 M1 via local pip install of Python API and use of open_soma() call.