### PR TITLE
open_soma() alias handling changes

### DIFF
--- a/api/python/cellxgene_census/src/cellxgene_census/_open.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/_open.py
@@ -54,7 +54,7 @@ def _open_soma(locator: CensusLocator, context: Optional[soma.options.SOMATileDB
 
 def open_soma(
     *,
-    census_version: Optional[str] = None,
+    census_version: Optional[str] = "stable",
     uri: Optional[str] = None,
     context: Optional[soma.options.SOMATileDBContext] = None,
 ) -> soma.Collection:
@@ -113,24 +113,29 @@ def open_soma(
         return _open_soma({"uri": uri, "s3_region": None}, context)
 
     if census_version is None:
-        census_version = "stable"
+        raise ValueError("Must specify either a census version or an explicit URI.")
 
     try:
         description = get_census_version_description(census_version)  # raises
     except KeyError:
+        # TODO: After the first "stable" is available, this conditional can be removed (keep the 'else' logic)
         if census_version == "stable":
             description = get_census_version_description("latest")
             api_logger.warning(
-                f"The \"{census_version}\" Census version is not yet available. Using {description['release_build']} Census version."
+                f'The "{census_version}" Census version is not yet available. Using "latest" Census version '
+                f"instead."
             )
         else:
             raise ValueError(
-                f'The "{census_version}" Census version is not valid. Use get_census_version_directory() to retrieve available versions.'
-            )
+                f'The "{census_version}" Census version is not valid. Use get_census_version_directory() to retrieve '
+                f"available versions."
+            ) from None
 
     if description["alias"]:
         api_logger.info(
-            f"""The \"{description['alias']}\" release is currently {description['release_build']}. Specify `census_version=\"{description['release_build']}\"` in future calls to open_soma() to ensure data consistency"""
+            f"The \"{description['alias']}\" release is currently {description['release_build']}. Specify "
+            f"'census_version=\"{description['release_build']}\"' in future calls to open_soma() to ensure data "
+            "consistency."
         )
 
     return _open_soma(description["soma"], context)

--- a/api/python/cellxgene_census/src/cellxgene_census/_open.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/_open.py
@@ -6,7 +6,7 @@
 
 Contains methods to open publicly hosted versions of Census object and access its source datasets.
 """
-
+import logging
 import os.path
 import urllib.parse
 from typing import Any, Dict, Optional
@@ -25,6 +25,10 @@ DEFAULT_TILEDB_CONFIGURATION: Dict[str, Any] = {
     # Temporary fix for Mac OSX, to be removed by https://github.com/chanzuckerberg/cellxgene-census/issues/415
     "vfs.s3.ca_file": certifi.where(),
 }
+
+api_logger = logging.getLogger("cellxgene_census")
+api_logger.setLevel(logging.INFO)
+api_logger.addHandler(logging.StreamHandler())
 
 
 def _open_soma(locator: CensusLocator, context: Optional[soma.options.SOMATileDBContext] = None) -> soma.Collection:
@@ -50,7 +54,7 @@ def _open_soma(locator: CensusLocator, context: Optional[soma.options.SOMATileDB
 
 def open_soma(
     *,
-    census_version: Optional[str] = "latest",
+    census_version: Optional[str] = None,
     uri: Optional[str] = None,
     context: Optional[soma.options.SOMATileDBContext] = None,
 ) -> soma.Collection:
@@ -109,9 +113,26 @@ def open_soma(
         return _open_soma({"uri": uri, "s3_region": None}, context)
 
     if census_version is None:
-        raise ValueError("Must specify either a census version or an explicit URI.")
+        census_version = "stable"
 
-    description = get_census_version_description(census_version)  # raises
+    try:
+        description = get_census_version_description(census_version)  # raises
+    except KeyError:
+        if census_version == "stable":
+            description = get_census_version_description("latest")
+            api_logger.warning(
+                f"The \"{census_version}\" Census version is not yet available. Using {description['release_build']} Census version."
+            )
+        else:
+            raise ValueError(
+                f'The "{census_version}" Census version is not valid. Use get_census_version_directory() to retrieve available versions.'
+            )
+
+    if description["alias"]:
+        api_logger.info(
+            f"""The \"{description['alias']}\" release is currently {description['release_build']}. Specify `census_version=\"{description['release_build']}\"` in future calls to open_soma() to ensure data consistency"""
+        )
+
     return _open_soma(description["soma"], context)
 
 

--- a/api/python/cellxgene_census/src/cellxgene_census/_release_directory.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/_release_directory.py
@@ -6,7 +6,6 @@
 
 Methods to retrieve information about versions of the publicly hosted Census object.
 """
-
 from typing import Dict, Optional, Union, cast
 
 import requests
@@ -31,6 +30,7 @@ CensusVersionDescription = TypedDict(
         "release_build": str,  # date of build
         "soma": CensusLocator,  # SOMA objects locator
         "h5ads": CensusLocator,  # source H5ADs locator
+        "alias": Optional[str],  # the alias of this entry
     },
 )
 CensusDirectory = Dict[CensusVersionName, Union[CensusVersionName, CensusVersionDescription]]
@@ -117,6 +117,7 @@ def get_census_version_directory() -> Dict[CensusVersionName, CensusVersionDescr
     for census_version in list(directory.keys()):
         # Strings are aliases for other census_version
         points_at = directory[census_version]
+        alias = census_version if isinstance(points_at, str) else None
         while isinstance(points_at, str):
             # resolve aliases
             if points_at not in directory:
@@ -127,7 +128,8 @@ def get_census_version_directory() -> Dict[CensusVersionName, CensusVersionDescr
             points_at = directory[points_at]
 
         if isinstance(points_at, dict):
-            directory[census_version] = points_at
+            directory[census_version] = points_at.copy()
+            directory[census_version]["alias"] = alias
 
     # Cast is safe, as we have removed all aliases
     return cast(Dict[CensusVersionName, CensusVersionDescription], directory)

--- a/api/python/cellxgene_census/src/cellxgene_census/_release_directory.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/_release_directory.py
@@ -129,7 +129,7 @@ def get_census_version_directory() -> Dict[CensusVersionName, CensusVersionDescr
 
         if isinstance(points_at, dict):
             directory[census_version] = points_at.copy()
-            directory[census_version]["alias"] = alias
+            cast(CensusVersionDescription, directory[census_version])["alias"] = alias
 
     # Cast is safe, as we have removed all aliases
     return cast(Dict[CensusVersionName, CensusVersionDescription], directory)

--- a/api/python/cellxgene_census/tests/test_directory.py
+++ b/api/python/cellxgene_census/tests/test_directory.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any, Mapping, cast
 
 import pytest
 import requests_mock as rm
@@ -55,11 +55,11 @@ def test_get_census_version_directory(directory_mock: Any) -> None:
 
     assert "_dangling" not in directory
 
-    assert directory["2022-11-01"] == DIRECTORY_JSON["2022-11-01"] | {"alias": None}
-    assert directory["2022-10-01"] == DIRECTORY_JSON["2022-10-01"] | {"alias": None}
+    assert directory["2022-11-01"] == cast(Mapping[str, Any], DIRECTORY_JSON["2022-11-01"]) | {"alias": None}
+    assert directory["2022-10-01"] == cast(Mapping[str, Any], DIRECTORY_JSON["2022-10-01"]) | {"alias": None}
 
-    assert directory["latest"] == DIRECTORY_JSON["2022-11-01"] | {"alias": "latest"}
-    assert directory["stable"] == DIRECTORY_JSON["2022-10-01"] | {"alias": "stable"}
+    assert directory["latest"] == cast(Mapping[str, Any], DIRECTORY_JSON["2022-11-01"]) | {"alias": "latest"}
+    assert directory["stable"] == cast(Mapping[str, Any], DIRECTORY_JSON["2022-10-01"]) | {"alias": "stable"}
 
     for tag in directory:
         assert directory[tag] == cellxgene_census.get_census_version_description(tag)

--- a/api/python/cellxgene_census/tests/test_directory.py
+++ b/api/python/cellxgene_census/tests/test_directory.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, cast
+from typing import Any
 
 import pytest
 import requests_mock as rm
@@ -55,11 +55,11 @@ def test_get_census_version_directory(directory_mock: Any) -> None:
 
     assert "_dangling" not in directory
 
-    assert directory["2022-11-01"] == cast(Mapping[str, Any], DIRECTORY_JSON["2022-11-01"]) | {"alias": None}
-    assert directory["2022-10-01"] == cast(Mapping[str, Any], DIRECTORY_JSON["2022-10-01"]) | {"alias": None}
+    assert directory["2022-11-01"] == {**DIRECTORY_JSON["2022-11-01"], "alias": None}  # type: ignore
+    assert directory["2022-10-01"] == {**DIRECTORY_JSON["2022-10-01"], "alias": None}  # type: ignore
 
-    assert directory["latest"] == cast(Mapping[str, Any], DIRECTORY_JSON["2022-11-01"]) | {"alias": "latest"}
-    assert directory["stable"] == cast(Mapping[str, Any], DIRECTORY_JSON["2022-10-01"]) | {"alias": "stable"}
+    assert directory["latest"] == {**DIRECTORY_JSON["2022-11-01"], "alias": "latest"}  # type: ignore
+    assert directory["stable"] == {**DIRECTORY_JSON["2022-10-01"], "alias": "stable"}  # type: ignore
 
     for tag in directory:
         assert directory[tag] == cellxgene_census.get_census_version_description(tag)

--- a/api/python/cellxgene_census/tests/test_open.py
+++ b/api/python/cellxgene_census/tests/test_open.py
@@ -1,13 +1,17 @@
 import pathlib
+import re
 import time
+from unittest.mock import patch
 
 import anndata
 import numpy as np
 import pytest
+import requests_mock as rm
 import tiledbsoma as soma
 
 import cellxgene_census
 from cellxgene_census._open import DEFAULT_TILEDB_CONFIGURATION
+from cellxgene_census._release_directory import CELL_CENSUS_RELEASE_DIRECTORY_URL
 
 
 @pytest.mark.live_corpus
@@ -52,9 +56,65 @@ def test_open_soma_with_context() -> None:
         assert census.context.timestamp_ms == timestamp_ms
 
 
-def test_open_soma_errors() -> None:
-    with pytest.raises(ValueError):
-        cellxgene_census.open_soma(census_version=None)
+def test_open_soma_errors(requests_mock: rm.Mocker) -> None:
+    requests_mock.get(CELL_CENSUS_RELEASE_DIRECTORY_URL, json={})
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            'The "does-not-exist" Census version is not valid. Use get_census_version_directory() to retrieve available versions.'
+        ),
+    ):
+        cellxgene_census.open_soma(census_version="does-not-exist")
+
+
+def test_open_soma_defaults_to_latest_if_missing_stable(requests_mock: rm.Mocker) -> None:
+    dir_missing_stable = {
+        "latest": "2022-11-01",
+        "2022-11-01": {
+            "release_date": "2022-11-30",
+            "release_build": "2022-11-01",
+            "soma": {
+                "uri": "s3://cellxgene-data-public/cell-census/2022-11-01/soma/",
+                "s3_region": "us-west-2",
+            },
+            "h5ads": {
+                "uri": "s3://cellxgene-data-public/cell-census/2022-11-01/h5ads/",
+                "s3_region": "us-west-2",
+            },
+        },
+    }
+
+    requests_mock.get(CELL_CENSUS_RELEASE_DIRECTORY_URL, json=dir_missing_stable)
+    with patch("cellxgene_census._open._open_soma") as m:
+        cellxgene_census.open_soma(census_version="stable")
+        m.assert_called_once_with(
+            {"uri": "s3://cellxgene-data-public/cell-census/2022-11-01/soma/", "s3_region": "us-west-2"}, None
+        )
+
+
+def test_open_soma_defaults_to_stable(requests_mock: rm.Mocker) -> None:
+    directory_with_stable = {
+        "stable": "2022-10-01",
+        "2022-10-01": {
+            "release_date": "2022-10-30",
+            "release_build": "2022-10-01",
+            "soma": {
+                "uri": "s3://cellxgene-data-public/cell-census/2022-10-01/soma/",
+                "s3_region": "us-west-2",
+            },
+            "h5ads": {
+                "uri": "s3://cellxgene-data-public/cell-census/2022-10-01/h5ads/",
+                "s3_region": "us-west-2",
+            },
+        },
+    }
+
+    requests_mock.get(CELL_CENSUS_RELEASE_DIRECTORY_URL, json=directory_with_stable)
+    with patch("cellxgene_census._open._open_soma") as m:
+        cellxgene_census.open_soma()
+        m.assert_called_once_with(
+            {"uri": "s3://cellxgene-data-public/cell-census/2022-10-01/soma/", "s3_region": "us-west-2"}, None
+        )
 
 
 @pytest.mark.live_corpus


### PR DESCRIPTION
Resolves #433 

- default to stable release
- notify user when an alias is used
- notify user if stable alias is not defined

New output looks like:

```
import cellxgene_census as cc
c = cc.open_soma()
The "stable" Census version is not yet available. Using "latest" Census version instead.
The "latest" release is currently 2023-04-25. Specify 'census_version="2023-04-25"' in future calls to open_soma() to ensure data consistency.

c = cc.open_soma(census_version="stable")
The "stable" Census version is not yet available. Using "latest" Census version instead.
The "latest" release is currently 2023-04-25. Specify 'census_version="2023-04-25"' in future calls to open_soma() to ensure data consistency.

c = cc.open_soma(census_version="latest")
The "latest" release is currently 2023-04-25. Specify 'census_version="2023-04-25"' in future calls to open_soma() to ensure data consistency.

c = cc.open_soma(census_version="2023-04-25")
# silence is bliss

c = cc.open_soma(census_version="bad")
Traceback (most recent call last):
  File "/Users/atolopko/venvs/cellxgene-census/lib/python3.9/site-packages/IPython/core/interactiveshell.py", line 3508, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-7-16de8ccb18df>", line 1, in <module>
    c = cc.open_soma(census_version="bad")
  File "/Users/atolopko/dev/cxg/cell-census/cellxgene-census/api/python/cellxgene_census/src/cellxgene_census/_open.py", line 129, in open_soma
    raise ValueError(
ValueError: The "bad" Census version is not valid. Use get_census_version_directory() to retrieve available versions.

c = cc.open_soma(census_version=None)
Traceback (most recent call last):
  File "/Users/atolopko/venvs/cellxgene-census/lib/python3.9/site-packages/IPython/core/interactiveshell.py", line 3508, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-8-c137ddd80f7f>", line 1, in <module>
    c = cc.open_soma(census_version=None)
  File "/Users/atolopko/dev/cxg/cell-census/cellxgene-census/api/python/cellxgene_census/src/cellxgene_census/_open.py", line 116, in open_soma
    raise ValueError("Must specify either a census version or an explicit URI.")
ValueError: Must specify either a census version or an explicit URI.
```