### PR TITLE
Pin tiledb version as work-around

### DIFF
--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -40,6 +40,8 @@ dependencies= [
     "scipy",
     # Temporary fix for Mac OSX, to be removed by https://github.com/chanzuckerberg/cellxgene-census/issues/415
     "certifi",
+    # Temporary fix for https://github.com/single-cell-data/TileDB-SOMA/issues/1322, remove when we update to tiledbsoma>1.2.2
+    "tiledb>=0.21.3",
 ]
 
 [project.urls]

--- a/api/python/cellxgene_census/src/cellxgene_census/_release_directory.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/_release_directory.py
@@ -37,7 +37,7 @@ CensusDirectory = Dict[CensusVersionName, Union[CensusVersionName, CensusVersion
 
 
 # URL for the default top-level directory of all public data
-CELL_CENSUS_RELEASE_DIRECTORY_URL = "https://census.cellxgene.cziscience.com/cellxgene-census/release.json"
+CELL_CENSUS_RELEASE_DIRECTORY_URL = "https://census.cellxgene.cziscience.com/cell-census/release.json"
 
 
 def get_census_version_description(census_version: str) -> CensusVersionDescription:


### PR DESCRIPTION
Primary change:  pin the tiledb version dependency to >=0.21.3 to account for a missing dependency in tiledbsoma==1.2.2.  See single-cell-data/TileDB-SOMA#1322 for details.   This work-around can be removed when the issue is resolved upstream, and we bump our tiledbsoma pin.

Secondary change:  reverted the URL change for the release.json bootstrap file, introduced in #443.  This will be further updated when the final permalink, and infra changes to support that permalink, are in place.


NOTE:  this PR did not revert the R bootstrap URL.  That needs to be done at some point before it is released. CC: @mlin and @pablo-gar 