### PR TITLE
update release bootstrap URL to public permalink

### DIFF
--- a/api/python/cellxgene_census/src/cellxgene_census/_release_directory.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/_release_directory.py
@@ -37,7 +37,7 @@ CensusDirectory = Dict[CensusVersionName, Union[CensusVersionName, CensusVersion
 
 
 # URL for the default top-level directory of all public data
-CELL_CENSUS_RELEASE_DIRECTORY_URL = "https://census.cellxgene.cziscience.com/cell-census/release.json"
+CELL_CENSUS_RELEASE_DIRECTORY_URL = "https://census.cellxgene.cziscience.com/cellxgene-census/v1/release.json"
 
 
 def get_census_version_description(census_version: str) -> CensusVersionDescription:

--- a/api/r/cellxgene.census/R/release_directory.R
+++ b/api/r/cellxgene.census/R/release_directory.R
@@ -1,4 +1,4 @@
-CELL_CENSUS_RELEASE_DIRECTORY_URL <- "https://census.cellxgene.cziscience.com/cell-census/release.json"
+CELL_CENSUS_RELEASE_DIRECTORY_URL <- "https://census.cellxgene.cziscience.com/cellxgene-census/v1/release.json"
 
 
 #' Get release description for given census version


### PR DESCRIPTION
The Python and R packages are updated to use the public permalink URL for the release directory bootstrap.
