### PR TITLE
Bump static census version in R tests

### DIFF
--- a/api/r/cellxgene.census/tests/testthat/test-release_directory.R
+++ b/api/r/cellxgene.census/tests/testthat/test-release_directory.R
@@ -1,6 +1,6 @@
 # A known-good Cell Census version. This may need updating if the version used
 # is withdrawn for any reason.
-KNOWN_CENSUS_VERSION <- "2023-04-04"
+KNOWN_CENSUS_VERSION <- "2023-05-08" # TODO: replace with a version tagged as LTS when available
 KNOWN_CENSUS_URI <- paste(
   "s3://cellxgene-data-public/cell-census/",
   KNOWN_CENSUS_VERSION,


### PR DESCRIPTION
The `2023-04-04` version that was pinned in the tests is expired, so this test is now failing. When an LTS version is available, we should switch to that.