### PR TITLE
run experimental tests conditionally

### DIFF
--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -37,11 +37,11 @@ jobs:
       - name: Test with pytest (API)
         if: matrix.python-version != '3.10'
         run: |
-          PYTHONPATH=. coverage run --parallel-mode -m pytest -v -rP --durations=20 -m "not experimental" ./api/python/cellxgene_census/tests/
+          PYTHONPATH=. coverage run --parallel-mode -m pytest -v -rP --durations=20 ./api/python/cellxgene_census/tests/
       - name: Test with pytest (API, with experimental)
         if: matrix.python-version == '3.10'
         run: |
-          PYTHONPATH=. coverage run --parallel-mode -m pytest -v -rP --durations=20 -m "experimental" ./api/python/cellxgene_census/tests/
+          PYTHONPATH=. coverage run --parallel-mode -m pytest -v -rP --durations=20 --experimental ./api/python/cellxgene_census/tests/
       - uses: actions/upload-artifact@v3
         with:
           name: coverage

--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -23,13 +23,25 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
+        if: matrix.python-version != '3.10'
+        run: |
+          python -m pip install -U pip setuptools wheel
+          pip install -r ./api/python/cellxgene_census/scripts/requirements-dev.txt
+          pip install -e './api/python/cellxgene_census/'
+      - name: Install dependencies (with experimental)
+        if: matrix.python-version == '3.10'
         run: |
           python -m pip install -U pip setuptools wheel
           pip install -r ./api/python/cellxgene_census/scripts/requirements-dev.txt
           pip install -e './api/python/cellxgene_census/[experimental]'
       - name: Test with pytest (API)
+        if: matrix.python-version != '3.10'
         run: |
-          PYTHONPATH=. coverage run --parallel-mode -m pytest -v -rP --durations=20 ./api/python/cellxgene_census/tests/
+          PYTHONPATH=. coverage run --parallel-mode -m pytest -v -rP --durations=20 -m "not experimental" ./api/python/cellxgene_census/tests/
+      - name: Test with pytest (API, with experimental)
+        if: matrix.python-version == '3.10'
+        run: |
+          PYTHONPATH=. coverage run --parallel-mode -m pytest -v -rP --durations=20 -m "experimental" ./api/python/cellxgene_census/tests/
       - uses: actions/upload-artifact@v3
         with:
           name: coverage

--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -77,6 +77,7 @@ plugins = "numpy.typing.mypy_plugin"
 markers = [
     "live_corpus: runs on the live CELLxGENE Census data corpus and small enough to run in CI",
     "expensive: too expensive to run regularly or in CI",
+    "experimental: tests for the `experimental` package",
 ]
 
 [tool.ruff]

--- a/api/python/cellxgene_census/tests/README.md
+++ b/api/python/cellxgene_census/tests/README.md
@@ -14,14 +14,19 @@ Then run the tests:
 
 ## Pytest Marks
 
-There are two Pytest marks you can use from the command line:
+There are various Pytest marks you can use from the command line:
 
 - live_corpus: tests that directly access the `latest` version of the Census. Enabled by default.
 - expensive: tests that are expensive (ie., cpu, memory, time). Disabled by default - enable with `--expensive`. Some of these tests are _very_ expensive, ie., require a very large memory host to succeed.
+- experimental: tests that are for code in the `experimental` package. Disabled by default - enable with `--experimental`. These tests require installation the optional Python packages installed via pip `pip install -e ./api/python/cellxgene_census/[experimental]`
 
 By default, only relatively cheap & fast tests are run. To enable `expensive` tests:
 
 > pytest --expensive ...
+
+To enable `experimental` tests:
+
+> pytest --experimental ...
 
 To disable `live_corpus` tests:
 
@@ -29,7 +34,7 @@ To disable `live_corpus` tests:
 
 You can also combine them, e.g.,
 
-> pytest -m 'not live_corpus' --expensive
+> pytest -m 'not live_corpus' --expensive --experimental
 
 # Acceptance (expensive) tests
 

--- a/api/python/cellxgene_census/tests/conftest.py
+++ b/api/python/cellxgene_census/tests/conftest.py
@@ -1,12 +1,31 @@
 import pytest
 
+TEST_MARKERS_SKIPPED_BY_DEFAULT = ["expensive", "experimental"]
+
 
 def pytest_addoption(parser: pytest.Parser) -> None:
-    parser.addoption(
-        "--expensive", action="store_true", dest="expensive", default=False, help="enable 'expensive' decorated tests"
-    )
+    for test_option in TEST_MARKERS_SKIPPED_BY_DEFAULT:
+        parser.addoption(
+            f"--{test_option}",
+            action="store_true",
+            dest=test_option,
+            default=False,
+            help=f"enable '{test_option}' decorated tests",
+        )
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    if not config.option.expensive:
-        config.option.markexpr = "not expensive"
+    """
+    Exclude tests marked with any of the TEST_MARKERS_SKIPPED_BY_DEFAULT values, unless the corresponding explicit
+    flag is specified by the user.
+    """
+    excluded_markexprs = []
+
+    for test_option in TEST_MARKERS_SKIPPED_BY_DEFAULT:
+        if not vars(config.option).get(test_option, False):
+            excluded_markexprs.append(test_option)
+
+    if config.option.markexpr and excluded_markexprs:
+        config.option.markexpr += " and "
+    config.option.markexpr += " and ".join([f"not {m}" for m in excluded_markexprs])
+    print(config.option.markexpr)

--- a/api/python/cellxgene_census/tests/conftest.py
+++ b/api/python/cellxgene_census/tests/conftest.py
@@ -28,4 +28,3 @@ def pytest_configure(config: pytest.Config) -> None:
     if config.option.markexpr and excluded_markexprs:
         config.option.markexpr += " and "
     config.option.markexpr += " and ".join([f"not {m}" for m in excluded_markexprs])
-    print(config.option.markexpr)

--- a/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
+++ b/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
@@ -117,6 +117,7 @@ def soma_experiment(
     return _factory.open((tmp_path / "exp").as_posix())
 
 
+@pytest.mark.experimental
 # noinspection PyTestParametrized
 @pytest.mark.parametrize("n_obs,n_vars,X_layer_names,X_value_gen", [(6, 3, ("raw",), pytorch_x_value_gen)])
 def test_non_batched(soma_experiment: Experiment) -> None:

--- a/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
+++ b/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
@@ -122,6 +122,7 @@ def test_non_batched(soma_experiment: Experiment) -> None:
     assert row[1].tolist() == [0, 0]
 
 
+@pytest.mark.experimental
 # noinspection PyTestParametrized,DuplicatedCode
 @pytest.mark.parametrize("n_obs,n_vars,X_layer_names,X_value_gen", [(6, 3, ("raw",), pytorch_x_value_gen)])
 def test_batching__all_batches_full_size(soma_experiment: Experiment) -> None:
@@ -142,6 +143,7 @@ def test_batching__all_batches_full_size(soma_experiment: Experiment) -> None:
         next(batch_iter)
 
 
+@pytest.mark.experimental
 # noinspection PyTestParametrized
 @pytest.mark.parametrize("n_obs,n_vars,X_layer_names,X_value_gen", [(5, 3, ("raw",), pytorch_x_value_gen)])
 def test_batching__partial_final_batch_size(soma_experiment: Experiment) -> None:
@@ -158,6 +160,7 @@ def test_batching__partial_final_batch_size(soma_experiment: Experiment) -> None
         next(batch_iter)
 
 
+@pytest.mark.experimental
 # noinspection PyTestParametrized,DuplicatedCode
 @pytest.mark.parametrize("n_obs,n_vars,X_layer_names,X_value_gen", [(3, 3, ("raw",), pytorch_x_value_gen)])
 def test_batching__exactly_one_batch(soma_experiment: Experiment) -> None:
@@ -174,6 +177,7 @@ def test_batching__exactly_one_batch(soma_experiment: Experiment) -> None:
         next(batch_iter)
 
 
+@pytest.mark.experimental
 # noinspection PyTestParametrized
 @pytest.mark.parametrize("n_obs,n_vars,X_layer_names,X_value_gen", [(6, 3, ("raw",), pytorch_x_value_gen)])
 def test_batching__empty_query_result(soma_experiment: Experiment) -> None:
@@ -191,6 +195,7 @@ def test_batching__empty_query_result(soma_experiment: Experiment) -> None:
         next(batch_iter)
 
 
+@pytest.mark.experimental
 # noinspection PyTestParametrized
 @pytest.mark.parametrize("n_obs,n_vars,X_layer_names,X_value_gen", [(6, 3, ("raw",), pytorch_x_value_gen)])
 def test_sparse_output__non_batched(soma_experiment: Experiment) -> None:
@@ -208,6 +213,7 @@ def test_sparse_output__non_batched(soma_experiment: Experiment) -> None:
     assert batch[0].to_dense().tolist() == [0, 1, 0]
 
 
+@pytest.mark.experimental
 # noinspection PyTestParametrized
 @pytest.mark.parametrize("n_obs,n_vars,X_layer_names,X_value_gen", [(6, 3, ("raw",), pytorch_x_value_gen)])
 def test_sparse_output__batched(soma_experiment: Experiment) -> None:
@@ -226,6 +232,7 @@ def test_sparse_output__batched(soma_experiment: Experiment) -> None:
     assert batch[0].to_dense().tolist() == [[0, 1, 0], [1, 0, 1], [0, 1, 0]]
 
 
+@pytest.mark.experimental
 # noinspection PyTestParametrized
 @pytest.mark.parametrize("n_obs,n_vars,X_layer_names,X_value_gen", [(3, 3, ("raw",), pytorch_x_value_gen)])
 def test_encoders(soma_experiment: Experiment) -> None:
@@ -246,6 +253,7 @@ def test_encoders(soma_experiment: Experiment) -> None:
     assert labels_decoded.tolist() == ["0", "1", "2"]
 
 
+@pytest.mark.experimental
 # noinspection PyTestParametrized,DuplicatedCode
 @pytest.mark.parametrize("n_obs,n_vars,X_layer_names,X_value_gen", [(3, 3, ("raw",), pytorch_x_value_gen)])
 def test_experiment_dataloader__non_batched(soma_experiment: Experiment) -> None:
@@ -258,6 +266,7 @@ def test_experiment_dataloader__non_batched(soma_experiment: Experiment) -> None
     assert row[1].tolist() == [0, 0]
 
 
+@pytest.mark.experimental
 # noinspection PyTestParametrized,DuplicatedCode
 @pytest.mark.parametrize("n_obs,n_vars,X_layer_names,X_value_gen", [(6, 3, ("raw",), pytorch_x_value_gen)])
 def test_experiment_dataloader__batched(soma_experiment: Experiment) -> None:
@@ -270,6 +279,7 @@ def test_experiment_dataloader__batched(soma_experiment: Experiment) -> None:
     assert batch[1].tolist() == [[0, 0], [1, 1], [2, 2]]
 
 
+@pytest.mark.experimental
 def test_experiment_dataloader__multiprocess_sparse_matrix__fails() -> None:
     mock_experiment = Mock(spec=Experiment)
     with pytest.raises(NotImplementedError):
@@ -278,6 +288,7 @@ def test_experiment_dataloader__multiprocess_sparse_matrix__fails() -> None:
         )
 
 
+@pytest.mark.experimental
 def test_experiment_dataloader__multiprocess_dense_matrix__ok() -> None:
     mock_experiment = Mock(spec=Experiment)
     dp = ExperimentDataPipe(
@@ -286,6 +297,7 @@ def test_experiment_dataloader__multiprocess_dense_matrix__ok() -> None:
     assert dp is not None
 
 
+@pytest.mark.experimental
 # noinspection PyTestParametrized,DuplicatedCode
 @pytest.mark.parametrize("n_obs,n_vars,X_layer_names,X_value_gen", [(10, 1, ("raw",), pytorch_x_value_gen)])
 def test_experiment_dataloader__splitting(soma_experiment: Experiment) -> None:
@@ -297,6 +309,7 @@ def test_experiment_dataloader__splitting(soma_experiment: Experiment) -> None:
     assert len(all_rows) == 7
 
 
+@pytest.mark.experimental
 # noinspection PyTestParametrized,DuplicatedCode
 @pytest.mark.parametrize("n_obs,n_vars,X_layer_names,X_value_gen", [(10, 1, ("raw",), pytorch_x_value_gen)])
 def test_experiment_dataloader__shuffling(soma_experiment: Experiment) -> None:
@@ -312,6 +325,7 @@ def test_experiment_dataloader__shuffling(soma_experiment: Experiment) -> None:
     assert data1_soma_joinids != data2_soma_joinids
 
 
+@pytest.mark.experimental
 # noinspection PyTestParametrized,DuplicatedCode
 @pytest.mark.parametrize("n_obs,n_vars,X_layer_names,X_value_gen", [(3, 3, ("raw",), pytorch_x_value_gen)])
 def test_experiment_dataloader__multiprocess_pickling(soma_experiment: Experiment) -> None:
@@ -331,6 +345,7 @@ def test_experiment_dataloader__multiprocess_pickling(soma_experiment: Experimen
     assert row is not None
 
 
+@pytest.mark.experimental
 @pytest.mark.skip(reason="TODO")
 def test_experiment_data_loader__unsupported_params__fails() -> None:
     pass

--- a/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
+++ b/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
@@ -11,9 +11,15 @@ from scipy.sparse import coo_matrix, spmatrix
 from somacore import AxisQuery
 from tiledbsoma import Experiment, _factory
 from tiledbsoma._collection import CollectionBase
-from torch import Tensor
 
-from cellxgene_census.experimental.ml.pytorch import ExperimentDataPipe, experiment_dataloader
+# conditionally import pytorch, as it is not a dependency of cellxgene-census
+try:
+    from torch import Tensor
+
+    from cellxgene_census.experimental.ml.pytorch import ExperimentDataPipe, experiment_dataloader
+except ImportError:
+    # this should only occur when not running `experimental`-marked tests
+    pass
 
 
 def pytorch_x_value_gen(shape: Tuple[int, int]) -> spmatrix:

--- a/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
+++ b/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
@@ -12,7 +12,7 @@ from somacore import AxisQuery
 from tiledbsoma import Experiment, _factory
 from tiledbsoma._collection import CollectionBase
 
-# conditionally import pytorch, as it is not a dependency of cellxgene-census
+# conditionally import torch, as it will not be available in all test environments
 try:
     from torch import Tensor
 

--- a/api/python/cellxgene_census/tests/test_open.py
+++ b/api/python/cellxgene_census/tests/test_open.py
@@ -200,6 +200,7 @@ def test_opening_census_without_anon_access_fails_with_bogus_creds() -> None:
         cellxgene_census.open_soma(census_version="latest", context=soma.SOMATileDBContext())
 
 
+@pytest.mark.live_corpus
 def test_can_open_with_anonymous_access() -> None:
     """
     With anonymous access, `open_soma` must be able to access the census even with bogus credentials


### PR DESCRIPTION
This is a sub-branch on `atol/pytorch-dataloader`, to segregate these changes in a separate PR for easier review.

Changes:
- pytest can now also be run with `--experimental` option to explicitly enable tests on the `experimental` sub-package (ie in addition to the `--expensive` option)
- GHA build only runs experimental tests for Python 3.10 to avoid some missing experimental code pkg dependencies for lower Python versions (torch==2.0.1 not avail for Python 3.7)
- fix bug where `pytest -m 'not live_corpus' --experimental` not working
