### PR TITLE
Support loading configuration from env vars

### DIFF
--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_state.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_state.py
@@ -108,6 +108,9 @@ class CensusBuildConfig(Namespace):
 
     def __init__(self, **kwargs: Any):
         config = self.defaults.copy()
+        for k in config.keys():
+            if k.upper() in os.environ:
+                config[k] = os.environ[k.upper()]
         config.update(kwargs)
         super().__init__(**config)
 


### PR DESCRIPTION
Since AWS Batch is most easily configured via env vars, this PR allows reading the configuration from them. Note that this only checks if a key in the default configuration is present as an env var and, if so, replaces the value with it. Recommendations for alternative solutions are appreciated.