### PR TITLE
pre-commit config update and fixes for resulting lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: (^doc/)|(.*/venv/)
 default_stages: [commit]
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black-jupyter
         name: black-notebooks
@@ -18,7 +18,7 @@ repos:
         args: ["--config", "./tools/pyproject.toml"]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.249
+    rev: v0.0.272
     hooks:
       - id: ruff
         name: ruff-cellxgene-census
@@ -30,13 +30,14 @@ repos:
         args: [ "--config=./tools/pyproject.toml", "--fix" ]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.0.1
+    rev: v1.3.0
     hooks:
       - id: mypy
         name: mypy-cellxgene-census
         files: ^api/python/cellxgene_census
         args: ["--config-file=./api/python/cellxgene_census/pyproject.toml"]
         additional_dependencies:
+          - attrs
           - types-requests
           - pytest
           - pandas-stubs
@@ -44,10 +45,11 @@ repos:
           - typing_extensions
           - types-setuptools
       - id: mypy
-        name: mypy-tools
-        files: ^tools
-        args: ["--config-file=./tools/pyproject.toml"]
+        name: mypy-tools-cellxgene_census_builder
+        files: ^tools/cellxgene_census_builder
+        args: ["--config-file=./tools/cellxgene_census_builder/pyproject.toml"]
         additional_dependencies:
+          - attrs
           - types-requests
           - pytest
           - pandas-stubs
@@ -57,6 +59,6 @@ repos:
           - types-PyYAML
 
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.6.4
+    rev: 1.7.0
     hooks:
       - id: nbqa-black

--- a/api/python/cellxgene_census/tests/test_open.py
+++ b/api/python/cellxgene_census/tests/test_open.py
@@ -8,6 +8,7 @@ import anndata
 import numpy as np
 import pytest
 import requests_mock as rm
+import tiledb
 import tiledbsoma as soma
 
 import cellxgene_census
@@ -196,7 +197,7 @@ def test_opening_census_without_anon_access_fails_with_bogus_creds() -> None:
     os.environ["AWS_ACCESS_KEY_ID"] = "fake_id"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "fake_key"
     # Passing an empty context
-    with pytest.raises(Exception):
+    with pytest.raises(tiledb.TileDBError, match=r"The AWS Access Key Id you provided does not exist in our records"):
         cellxgene_census.open_soma(census_version="latest", context=soma.SOMATileDBContext())
 
 

--- a/tools/cellxgene_census_builder/pyproject.toml
+++ b/tools/cellxgene_census_builder/pyproject.toml
@@ -63,7 +63,7 @@ root = "../.."
 
 [tool.black]
 line-length = 120
-target_version = ['py39']
+target_version = ['py10']
 
 [tool.mypy]
 show_error_codes = true

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/experiment_builder.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/experiment_builder.py
@@ -60,7 +60,7 @@ PresenceResults = Tuple[PresenceResult, ...]
 tissue_mapper: TissueMapper = TissueMapper()
 
 
-def _assert_open_for_write(obj: somacore.SOMAObject) -> None:
+def _assert_open_for_write(obj: Optional[somacore.SOMAObject]) -> None:
     assert obj is not None
     assert obj.exists(obj.uri)
     assert obj.mode == "w"

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/util.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/util.py
@@ -125,7 +125,9 @@ def get_git_commit_sha() -> str:
 
     import git  # Scoped import - this requires the git executable to exist on the machine
 
-    repo = git.Repo(search_parent_directories=True)
+    # work around https://github.com/gitpython-developers/GitPython/issues/1349
+    # by explicitly referencing git.repo.base.Repo instead of git.Repo
+    repo = git.repo.base.Repo(search_parent_directories=True)
     hexsha: str = repo.head.object.hexsha
     return hexsha
 
@@ -136,6 +138,8 @@ def is_git_repo_dirty() -> bool:
     """
     import git  # Scoped import - this requires the git executable to exist on the machine
 
-    repo = git.Repo(search_parent_directories=True)
+    # work around https://github.com/gitpython-developers/GitPython/issues/1349
+    # by explicitly referencing git.repo.base.Repo instead of git.Repo
+    repo = git.repo.base.Repo(search_parent_directories=True)
     is_dirty: bool = repo.is_dirty()
     return is_dirty

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/util.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/util.py
@@ -71,7 +71,7 @@ class ProcessResourceGetter:
 
         with open("/proc/self/status") as f:
             status = f.read()
-            thread_count = int(re.split(".*\nThreads:\t(\d+)\n.*", status)[1])
+            thread_count = int(re.split(r".*\nThreads:\t(\d+)\n.*", status)[1])
             self.max_thread_count = max(thread_count, self.max_thread_count)
         return thread_count
 


### PR DESCRIPTION
The mypy pre-commit hooks for the builder were broken.  This fixes them, and fixes a bunch of lint I found in the Python code while doing this work.

This also fixes several new errors caught by more recent versions of Ruff.

We need a regular chore to run `pre-commit autoupdate`

*Note to reviewers:* this PR is stacked on the HVG notebook PR #536.    When approved, I'll update that PR, and then merge them together.

changes:
* update pre-commit hooks to latest versions
* add explicit `attrs` dependency for mypy, as it has a built-in extension enabled by this config
* fix various real lint / deprecation found after this update.