### PR TITLE
Fix MacOS failing tests

### DIFF
--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13]
-        python-version: ["3.7, "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -11,10 +11,11 @@ jobs:
   unit_tests_python_api:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{matrix.os}}
+    if: matrix.python-version != '3.7' && matrix.os != 'macos-latest'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -13,9 +13,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        exclude:
+          - os: macos-latest
+          - python-version: 3.7
 
     runs-on: ${{matrix.os}}
-    if: matrix.python-version != '3.7' && matrix.os != 'macos-latest'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         exclude:
           - os: macos-latest
-          - python-version: 3.7
+            python-version: 3.7
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -11,8 +11,8 @@ jobs:
   unit_tests_python_api:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        os: [ubuntu-latest, macos-13]
+        python-version: ["3.7, "3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
Temporarily remove Python 3.7 on MacOS testing due to a bug. Revert when https://github.com/actions/setup-python/issues/682 is fixed.