### PR TITLE
Avoid unnecessary re-initialization of ExperimentDataPipe in mp mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         args: ["--config", "./tools/pyproject.toml"]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.272
+    rev: v0.0.275
     hooks:
       - id: ruff
         name: ruff-cellxgene-census
@@ -30,7 +30,7 @@ repos:
         args: [ "--config=./tools/pyproject.toml", "--fix" ]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.3.0
+    rev: v1.4.0
     hooks:
       - id: mypy
         name: mypy-cellxgene-census

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
@@ -142,6 +142,7 @@ class _ObsAndXIterator(Iterator[ObsDatum]):
         obs_encoded = pd.DataFrame(
             data={"soma_joinid": obs.soma_joinid}, columns=obs.columns, dtype=np.int64, index=obs.index
         )
+        # TODO: Encode the entire SOMA batch at once in _read_partial_torch_batch()
         for col, enc in self.encoders.items():
             obs_encoded[col] = enc.transform(obs[col])
 

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
@@ -89,7 +89,7 @@ class _ObsAndXIterator(Iterator[ObsAndXDatum]):
     obs_tables_iter: somacore.ReadIter[pa.Table]
     """Iterates the SOMA batches (tables) of obs data"""
 
-    obs_batch_: pd.DataFrame = pd.DataFrame()
+    obs_batch: pd.DataFrame = pd.DataFrame()
     """The current SOMA batch of obs data"""
 
     X_batch: scipy.matrix = None
@@ -124,7 +124,7 @@ class _ObsAndXIterator(Iterator[ObsAndXDatum]):
 
         while len(obs) < self.batch_size:
             try:
-                obs_partial, X_partial = self._read_partial_torch_batch(self.batch_size)
+                obs_partial, X_partial = self._read_partial_torch_batch(self.batch_size - len(obs))
                 obs = pd.concat([obs, obs_partial], axis=0)
                 X = sparse.vstack([X, X_partial])
             except StopIteration:
@@ -162,13 +162,20 @@ class _ObsAndXIterator(Iterator[ObsAndXDatum]):
         return X_tensor, obs_tensor
 
     def _read_partial_torch_batch(self, batch_size: int) -> Tuple[pd.DataFrame, sparse.csr_matrix]:
-        safe_batch_size = min(batch_size, len(self.obs_batch) - self.i)
-        slice_ = slice(self.i, self.i + safe_batch_size)
-        assert slice_.stop <= self.obs_batch_.shape[0]
+        if not (0 <= self.i < len(self.obs_batch)):
+            self.obs_batch, self.X_batch = self.next_soma_batch()
+            self.i = 0
 
-        obs_rows = self.obs_batch.iloc[slice_]
+        obs_batch = self.obs_batch
+        X_batch = self.X_batch
+
+        safe_batch_size = min(batch_size, len(obs_batch) - self.i)
+        slice_ = slice(self.i, self.i + safe_batch_size)
+        assert slice_.stop <= obs_batch.shape[0]
+
+        obs_rows = obs_batch.iloc[slice_]
         assert obs_rows["soma_joinid"].is_unique
-        X_csr_scipy = self.X_batch[slice_]
+        X_csr_scipy = X_batch[slice_]
         assert safe_batch_size == obs_rows.shape[0]
         assert obs_rows.shape[0] == X_csr_scipy.shape[0]
 
@@ -176,36 +183,27 @@ class _ObsAndXIterator(Iterator[ObsAndXDatum]):
 
         return obs_rows, X_csr_scipy
 
-    @property
     # TODO: Retrieve next batch asynchronously, so it's available before the current batch's iteration ends
-    def obs_batch(self) -> pd.DataFrame:
-        """
-        Returns the current SOMA batch of obs rows.
-        If the current SOMA batch has been fully iterated, loads the next SOMA batch of both obs and X data and returns
-        the new obs batch (only).
-        Raises ``StopIteration`` if there are no more SOMA batches to retrieve.
-        """
-        if 0 <= self.i < len(self.obs_batch_):
-            return self.obs_batch_
-
-        pytorch_logger.debug("Retrieving next TileDB-SOMA batch...")
+    def next_soma_batch(self) -> Tuple[pd.DataFrame, scipy.matrix]:
+        pytorch_logger.debug("Retrieving next SOMA batch...")
         start_time = time()
         # If no more batches to iterate through, raise StopIteration, as all iterators do when at end
         obs_table = next(self.obs_tables_iter)
-        self.obs_batch_ = obs_table.to_pandas()
+        obs_batch = obs_table.to_pandas()
+
         # handle case of empty result (first batch has 0 rows)
-        if len(self.obs_batch_) == 0:
+        if len(obs_batch) == 0:
             raise StopIteration
-        self.X_batch = _fast_csr.read_scipy_csr(self.X, obs_table["soma_joinid"].combine_chunks(), self.var_joinids)
-        assert self.obs_batch_.shape[0] == self.X_batch.shape[0]
-        self.i = 0
-        self.stats.n_obs += self.X_batch.shape[0]
-        self.stats.nnz += self.X_batch.nnz
+
+        X_batch = _fast_csr.read_scipy_csr(self.X, obs_table["soma_joinid"].combine_chunks(), self.var_joinids)
+        assert obs_batch.shape[0] == X_batch.shape[0]
+        self.stats.n_obs += X_batch.shape[0]
+        self.stats.nnz += X_batch.nnz
         self.stats.elapsed += int(time() - start_time)
         self.stats.n_soma_batches += 1
         # TODO: also show per-batch stats (non-cumulative)
-        pytorch_logger.debug(f"Retrieved batch: shape={self.X_batch.shape}, cum_stats: {self.stats}")
-        return self.obs_batch_
+        pytorch_logger.debug(f"Retrieved batch: shape={X_batch.shape}, cum_stats: {self.stats}")
+        return obs_batch, X_batch
 
 
 class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsAndXDatum]]):  # type: ignore
@@ -322,23 +320,21 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsAndXDatum]]):  # type: ig
 
         partition, num_partitions = worker_info.id, worker_info.num_workers
 
-        partition_size = len(ids) // num_partitions
-        partition_start = partition_size * partition
-        partition_end_excl = min(len(ids), partition_start + partition_size)
-        ids = ids[partition_start:partition_end_excl]
+        partitions = np.array_split(ids, num_partitions)
+        ids = partitions[partition]
 
-        if pytorch_logger.isEnabledFor(logging.DEBUG):
-            if len(ids) > 0:
-                joinids_start = ids[0]
-                joinids_end = ids[-1]
-            else:
-                joinids_start = joinids_end = 0
+        if pytorch_logger.isEnabledFor(logging.DEBUG) and len(ids) > 0:
+            joinids_start = ids[0]
+            joinids_end = ids[-1]
+            lens = [len(p) for p in partitions]
+            partition_start = sum(lens[:partition])
+            partition_end_excl = partition_start + lens[partition]
 
             pytorch_logger.debug(
                 f"Process {os.getpid()} handling partition {partition + 1} of {num_partitions}, "
-                f"index range={partition_start}:{partition_end_excl}, "
-                f"soma_joinid range={joinids_start}:{joinids_end}, "
-                f"{partition_size:}"
+                f"index range=[{partition_start}:{partition_end_excl}), "
+                f"soma_joinid range=[{joinids_start}:{joinids_end}], "
+                f"partition_size={len(ids)}"
             )
 
         return ids

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+from contextlib import contextmanager
 from datetime import timedelta
 from time import time
 from typing import Any, Dict, Iterator, Optional, Sequence, Tuple
@@ -25,7 +26,7 @@ from torch.utils.data.dataset import Dataset
 import cellxgene_census
 from cellxgene_census._open import _build_soma_tiledb_context
 
-ObsDatum = Tuple[Tensor, Tensor]
+ObsAndXDatum = Tuple[Tensor, Tensor]
 
 Encoders = Dict[str, LabelEncoder]
 
@@ -61,6 +62,7 @@ class Stats:
         )
 
 
+@contextmanager
 def _open_experiment(
     uri: str, aws_region: Optional[str] = None, soma_buffer_bytes: Optional[int] = None
 ) -> soma.Experiment:
@@ -74,10 +76,11 @@ def _open_experiment(
             }
         )
 
-    return soma.Experiment.open(uri, context=context)
+    with soma.Experiment.open(uri, context=context) as exp:
+        yield exp
 
 
-class _ObsAndXIterator(Iterator[ObsDatum]):
+class _ObsAndXIterator(Iterator[ObsAndXDatum]):
     """
     Iterates through a set of obs and related X rows, specified as ``soma_joinid``s. Encapsulates the batch-based data
     fetching from SOMA objects, providing row-based iteration.
@@ -97,34 +100,25 @@ class _ObsAndXIterator(Iterator[ObsDatum]):
 
     def __init__(
         self,
-        obs_joinids: npt.NDArray[np.int64],
+        X: soma.SparseNDArray,
+        obs_tables_iter: somacore.ReadIter[pa.Table],
         var_joinids: npt.NDArray[np.int64],
-        exp_uri: str,
-        aws_region: Optional[str],
-        measurement_name: str,
-        X_layer_name: str,
         batch_size: int,
         encoders: Dict[str, LabelEncoder],
         stats: Stats,
-        obs_column_names: Sequence[str],
         sparse_X: bool,
-        soma_buffer_bytes: Optional[int] = None,
     ) -> None:
+        self.X = X
+        self.obs_tables_iter = obs_tables_iter
         self.var_joinids = var_joinids
         self.batch_size = batch_size
         self.sparse_X = sparse_X
-
-        # holding reference to SOMA object prevents it from being closed
-        self.exp = _open_experiment(exp_uri, aws_region, soma_buffer_bytes=soma_buffer_bytes)
-        self.X: soma.SparseNDArray = self.exp.ms[measurement_name].X[X_layer_name]
-        self.obs_tables_iter = self.exp.obs.read(
-            coords=(obs_joinids,), batch_size=somacore.BatchSize(), column_names=obs_column_names
-        )
         self.encoders = encoders
         self.stats = stats
 
-    def __next__(self) -> ObsDatum:
-        # read the next torch batch, possibly across multiple soma batches
+    def __next__(self) -> ObsAndXDatum:
+        """Read the next torch batch, possibly across multiple soma batches"""
+
         obs: pd.DataFrame = pd.DataFrame()
         X: sparse.csr_matrix = sparse.csr_matrix((0, len(self.var_joinids)))
 
@@ -214,7 +208,7 @@ class _ObsAndXIterator(Iterator[ObsDatum]):
         return self.obs_batch_
 
 
-class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsDatum]]):  # type: ignore
+class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsAndXDatum]]):  # type: ignore
     """
     An iterable-style PyTorch ``DataPipe`` that reads obs and X data from a SOMA Experiment, and returns an iterator of
     tuples of PyTorch ``Tensor`` objects.
@@ -302,23 +296,19 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsDatum]]):  # type: ignore
 
         pytorch_logger.debug("Initializing ExperimentDataPipe")
 
-        # TODO: support multiple layers, per somacore.query.query.ExperimentAxisQuery.to_anndata()
-        # TODO: handle closing of `_query` (and transitively, `exp`) when iterator is no longer in use; may need be used as a ContextManager,
-        #  but not clear how we can do that when used by DataLoader
-        exp = _open_experiment(self.exp_uri, self.aws_region, soma_buffer_bytes=self.soma_buffer_bytes)
+        with _open_experiment(self.exp_uri, self.aws_region, soma_buffer_bytes=self.soma_buffer_bytes) as exp:
+            query = exp.axis_query(
+                measurement_name=self.measurement_name,
+                obs_query=self.obs_query,
+                var_query=self.var_query,
+            )
 
-        query = exp.axis_query(
-            measurement_name=self.measurement_name,
-            obs_query=self.obs_query,
-            var_query=self.var_query,
-        )
+            # The to_numpy() call is a workaround for a possible bug in TileDB-SOMA:
+            # https://github.com/single-cell-data/TileDB-SOMA/issues/1456
+            self._obs_joinids = query.obs_joinids().to_numpy()
+            self._var_joinids = query.var_joinids().to_numpy()
 
-        # The to_numpy() call is a workaround for a possible bug in TileDB-SOMA:
-        # https://github.com/single-cell-data/TileDB-SOMA/issues/1456
-        self._obs_joinids = query.obs_joinids().to_numpy()
-        self._var_joinids = query.var_joinids().to_numpy()
-
-        self._encoders = self._build_obs_encoders(query)
+            self._encoders = self._build_obs_encoders(query)
 
         self._initialized = True
 
@@ -353,7 +343,7 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsDatum]]):  # type: ignore
 
         return ids
 
-    def __iter__(self) -> Iterator[ObsDatum]:
+    def __iter__(self) -> Iterator[ObsAndXDatum]:
         self._init()
         assert self._obs_joinids is not None
         assert self._var_joinids is not None
@@ -364,20 +354,24 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsDatum]]):  # type: ignore
                 "(see https://github.com/pytorch/pytorch/issues/20248)"
             )
 
-        return _ObsAndXIterator(
-            obs_joinids=self._partition_obs_joinids(self._obs_joinids),
-            var_joinids=self._var_joinids,
-            exp_uri=self.exp_uri,
-            aws_region=self.aws_region,
-            measurement_name=self.measurement_name,
-            X_layer_name=self.layer_name,
-            batch_size=self.batch_size,
-            encoders=self.obs_encoders,
-            stats=self._stats,
-            obs_column_names=self.obs_column_names,
-            sparse_X=self.sparse_X,
-            soma_buffer_bytes=self.soma_buffer_bytes,
-        )
+        with _open_experiment(self.exp_uri, self.aws_region, soma_buffer_bytes=self.soma_buffer_bytes) as exp:
+            X: soma.SparseNDArray = exp.ms[self.measurement_name].X[self.layer_name]
+            obs_tables_iter = exp.obs.read(
+                coords=(self._partition_obs_joinids(self._obs_joinids),),
+                batch_size=somacore.BatchSize(),
+                column_names=self.obs_column_names,
+            )
+
+            for datum_ in _ObsAndXIterator(
+                X,
+                obs_tables_iter,
+                var_joinids=self._var_joinids,
+                batch_size=self.batch_size,
+                encoders=self.obs_encoders,
+                stats=self._stats,
+                sparse_X=self.sparse_X,
+            ):
+                yield datum_
 
     def __len__(self) -> int:
         self._init()
@@ -385,7 +379,7 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsDatum]]):  # type: ignore
 
         return len(self._obs_joinids)
 
-    def __getitem__(self, index: int) -> ObsDatum:
+    def __getitem__(self, index: int) -> ObsAndXDatum:
         raise NotImplementedError("IterDataPipe can only be iterated")
 
     def _build_obs_encoders(self, query: soma.ExperimentAxisQuery) -> Encoders:

--- a/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
+++ b/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
@@ -360,29 +360,6 @@ def test_experiment_dataloader__shuffling(soma_experiment: Experiment) -> None:
 
 
 @pytest.mark.experimental
-# noinspection PyTestParametrized,DuplicatedCode
-@pytest.mark.parametrize("obs_range,var_range,X_value_gen", [(3, 3, pytorch_x_value_gen)])
-def test_experiment_dataloader__multiprocess_pickling(soma_experiment: Experiment) -> None:
-    """
-    If the DataPipe is accessed prior to multiprocessing (num_workers > 0), its internal _query will be
-    initialized. But since it cannot be pickled, we must ensure it is ignored during pickling in multiprocessing mode.
-    This test verifies the correct pickling behavior is in place.
-    """
-
-    dp = ExperimentDataPipe(
-        soma_experiment,
-        measurement_name="RNA",
-        X_name="raw",
-        obs_column_names=["label"],
-    )
-    dl = experiment_dataloader(dp, num_workers=1)  # multiprocessing used when num_workers > 0
-    dp.obs_encoders.keys()  # trigger query building
-    row = next(iter(dl))  # trigger multiprocessing
-
-    assert row is not None
-
-
-@pytest.mark.experimental
 @pytest.mark.skip(reason="TODO")
 def test_experiment_data_loader__unsupported_params__fails() -> None:
     pass

--- a/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
+++ b/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
@@ -266,7 +266,7 @@ def test_encoders(soma_experiment: Experiment) -> None:
     assert isinstance(batch[1], Tensor)
 
     labels_encoded = batch[1][:, 1]
-    labels_decoded = exp_data_pipe.obs_encoders()["label"].inverse_transform(labels_encoded)
+    labels_decoded = exp_data_pipe.obs_encoders["label"].inverse_transform(labels_encoded)
     assert labels_decoded.tolist() == ["0", "1", "2"]
 
 
@@ -376,7 +376,7 @@ def test_experiment_dataloader__multiprocess_pickling(soma_experiment: Experimen
         obs_column_names=["label"],
     )
     dl = experiment_dataloader(dp, num_workers=1)  # multiprocessing used when num_workers > 0
-    dp.obs_encoders()  # trigger query building
+    dp.obs_encoders.keys()  # trigger query building
     row = next(iter(dl))  # trigger multiprocessing
 
     assert row is not None

--- a/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
+++ b/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
@@ -72,7 +72,7 @@ def test_hvg_vs_scanpy(
         with census["census_data"][experiment_name].axis_query(
             measurement_name="RNA", obs_query=soma.AxisQuery(value_filter=obs_value_filter)
         ) as query:
-            hvg = highly_variable_genes(query, **kwargs)
+            hvg = highly_variable_genes(query, **kwargs)  # type: ignore[arg-type]
             adata = query.to_anndata(X_name="raw")
 
     scanpy_hvg = sc.pp.highly_variable_genes(adata, inplace=False, **kwargs)
@@ -142,7 +142,7 @@ def test_hvg_error_cases() -> None:
         with census["census_data"]["mus_musculus"].axis_query(measurement_name="RNA") as query:
             # Only flavor="seurat_v3" is supported
             with pytest.raises(ValueError):
-                highly_variable_genes(query, flavor="oopsie")
+                highly_variable_genes(query, flavor="oopsie")  # type: ignore[arg-type]
 
 
 @pytest.mark.experimental

--- a/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
+++ b/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
@@ -15,7 +15,7 @@ def small_mem_context() -> soma.SOMATileDBContext:
     """used to keep memory usage smaller for GHA runners."""
     cfg = {
         "tiledb_config": {
-            "soma.init_buffer_bytes": 64 * 1024**2,
+            "soma.init_buffer_bytes": 32 * 1024**2,
             "vfs.s3.no_sign_request": True,
         },
     }
@@ -72,7 +72,7 @@ def test_hvg_vs_scanpy(
         with census["census_data"][experiment_name].axis_query(
             measurement_name="RNA", obs_query=soma.AxisQuery(value_filter=obs_value_filter)
         ) as query:
-            hvg = highly_variable_genes(query, **kwargs)  # type: ignore[arg-type]
+            hvg = highly_variable_genes(query, **kwargs)
             adata = query.to_anndata(X_name="raw")
 
     scanpy_hvg = sc.pp.highly_variable_genes(adata, inplace=False, **kwargs)
@@ -142,7 +142,7 @@ def test_hvg_error_cases() -> None:
         with census["census_data"]["mus_musculus"].axis_query(measurement_name="RNA") as query:
             # Only flavor="seurat_v3" is supported
             with pytest.raises(ValueError):
-                highly_variable_genes(query, flavor="oopsie")  # type: ignore[arg-type]
+                highly_variable_genes(query, flavor="oopsie")
 
 
 @pytest.mark.experimental


### PR DESCRIPTION
Partially resolves #524 

- In multiprocessing mode, if `ExperimentDataPipe` has been initialized prior to creating the child processes, each child process will receive a fully initialized object and the ExperimentAxisQuery and encoders do not need to be re-initialized.
- In particular, the full (unpartitioned) `_obs_joinids` array is cached and now partitioned for each child process at the time of `_ObsAndXIterator` instantiation.  In multiprocessing this should allow the PyArrow-backed soma_joinids to be memory-shared across child processes, without having to serialize the array.
- These changes also result in some code simplifications. Since the obs soma_joinids, var soma_joinds from ExperimentAxisQuery are directly cached, rather than the entire ExperimentAxisQuery object itself, the object pickling hacks could be removed (ExperimentAxisQuery cannot be pickled). Also, the lazy initialization behavior is simplified, as the obs_encoders are computed at the same time in the `ExperimentDataPipe._init()` method.
