### PR TITLE
Correct pytorch notebook header

### DIFF
--- a/api/python/notebooks/experimental/pytorch.ipynb
+++ b/api/python/notebooks/experimental/pytorch.ipynb
@@ -5,7 +5,7 @@
    "id": "9c8899e7",
    "metadata": {},
    "source": [
-    "## Training a PyTorch Model\n",
+    "# Training a PyTorch Model\n",
     "\n",
     "This tutorial shows how to train a Logistic Regression model in PyTorch using the Census API's `experimental.ml.ExperimentDataPipe` class. This is intended only to demonstrate the use of the `ExperimentDataPipe`, and not as an example of how to train a biologically useful model.\n",
     "\n",


### PR DESCRIPTION
Fixes top-level header which will correct indentation in doc-site:

<img width="435" alt="image" src="https://github.com/chanzuckerberg/cellxgene-census/assets/29237819/088eb7a6-51b9-4115-b15d-265b3f0f642f">
