### PR TITLE
require s3fs>=2021.06.1 where cache_regions kwarg is added

### DIFF
--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -37,7 +37,7 @@ dependencies= [
     "numpy>=1.21,<1.25",  # numpy is constrained by numba and the old pip solver
     "requests",
     "typing_extensions",
-    "s3fs",
+    "s3fs>=2021.06.1",
     "scipy",
     # Temporary fix for Mac OSX, to be removed by https://github.com/chanzuckerberg/cellxgene-census/issues/415
     "certifi",


### PR DESCRIPTION
I ran into the following error when trying to use the `download_source_h5ad` function after installing `cellxgene_census` via `pip` (version 1.2.1):

```txt
>>> cellxgene_census.download_source_h5ad("9d8e5dca-03a3-457d-b7fb-844c75735c83", to_path="/mnt/scratch/liurenmi/cellxgene/test.h5ad")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/home/liurenmi/software/anaconda3/envs/scgsp/lib/python3.9/site-packages/cellxgene_census/_open.py", line 226, in download_source_h5ad
    fs = s3fs.S3FileSystem(
  File "/mnt/home/liurenmi/software/anaconda3/envs/scgsp/lib/python3.9/site-packages/fsspec/spec.py", line 54, in __call__
    obj = super().__call__(*args, **kwargs)
  File "/mnt/home/liurenmi/software/anaconda3/envs/scgsp/lib/python3.9/site-packages/s3fs/core.py", line 187, in __init__
    self.s3 = self.connect()
  File "/mnt/home/liurenmi/software/anaconda3/envs/scgsp/lib/python3.9/site-packages/s3fs/core.py", line 280, in connect
    self.session = botocore.session.Session(**self.kwargs)
TypeError: __init__() got an unexpected keyword argument 'cache_regions'
```

This was due to an old version of `s3fs` being used, which does not have the `cache_regions` kwarg for `S3FileSystem`. The `cache_regions` kwarg is introduced in version `2021.06.1` (see the [changelog](https://s3fs.readthedocs.io/en/latest/changelog.html), as well as [diff](https://github.com/fsspec/s3fs/compare/2021.06.0...2021.06.1) between `2021.06.0` and `2021.06.1`)

So I think it might be good to require a minimum version of `2021.06.1` for `s3fs`