### PR TITLE
add progress bar option to download_source_h5ad to track download

### DIFF
--- a/api/python/cellxgene_census/src/cellxgene_census/_open.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/_open.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Optional
 import certifi
 import s3fs
 import tiledbsoma as soma
+from fsspec.callbacks import TqdmCallback, _DEFAULT_CALLBACK
 
 from ._release_directory import CensusLocator, get_census_version_description
 from ._util import _uri_join
@@ -189,7 +190,9 @@ def get_source_h5ad_uri(dataset_id: str, *, census_version: str = "latest") -> C
     return locator
 
 
-def download_source_h5ad(dataset_id: str, to_path: str, *, census_version: str = "latest") -> None:
+def download_source_h5ad(
+    dataset_id: str, to_path: str, *, census_version: str = "latest", progress: bool = False
+) -> None:
     """Download the source H5AD dataset, for the given `dataset_id`, to the user-specified
     file name.
 
@@ -200,6 +203,8 @@ def download_source_h5ad(dataset_id: str, to_path: str, *, census_version: str =
             The file name where the downloaded H5AD will be written.  Must not already exist.
         census_version:
             The census version name. Defaults to `latest`.
+        progress:
+            Display progress bar for downloading if set to True.
 
     Raises:
         ValueError: if the path already exists (i.e., will not overwrite
@@ -227,4 +232,5 @@ def download_source_h5ad(dataset_id: str, to_path: str, *, census_version: str =
         anon=True,
         cache_regions=True,
     )
-    fs.get_file(locator["uri"], to_path)
+    callback = TqdmCallback() if progress else _DEFAULT_CALLBACK
+    fs.get_file(locator["uri"], to_path, callback=callback)


### PR DESCRIPTION
Hi! The dataset-downloading functionality is fantastic! However, it's hard to estimate the download time for large files to allocate resources appropriately. Here, I added an option to show download progress using the `TqdmCallback` built into the `fsspec` library.