### PR TITLE
Add R acceptance tests, update Python acceptance tests

### DIFF
--- a/api/python/cellxgene_census/tests/README.md
+++ b/api/python/cellxgene_census/tests/README.md
@@ -52,6 +52,189 @@ When run, please record the results in this file (below) and commit the change t
 - any run notes
 - full output of: `pytest -v --durations=0 --expensive ./api/python/cellxgene_census/tests/`
 
+## 2023-06-23
+
+- Host: EC2 instance type: `r6id.x32xlarge`, all nvme mounted as swap.
+- Uname: Linux ip-172-31-52-152 5.19.0-1025-aws #26~22.04.1-Ubuntu SMP Mon Apr 24 01:58:15 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
+- Python & census versions:
+```
+>>> import cellxgene_census, tiledbsoma
+>>> tiledbsoma.show_package_versions()
+tiledbsoma.__version__        1.2.5
+TileDB-Py tiledb.version()    (0, 21, 5)
+TileDB core version           2.15.4
+libtiledbsoma version()       libtiledb=2.15.2
+python version                3.10.6.final.0
+OS version  
+>>> cellxgene_census.__version__
+'1.2.1'
+>>> cellxgene_census.get_census_version_description('latest')
+{'release_date': None, 'release_build': '2023-06-20', 'soma': {'uri': 's3://cellxgene-data-public/cell-census/2023-06-20/soma/', 's3_region': 'us-west-2'}, 'h5ads': {'uri': 's3://cellxgene-data-public/cell-census/2023-06-20/h5ads/', 's3_region': 'us-west-2'}, 'alias': 'latest'}
+```
+
+**Pytest output:**
+
+```
+============================= test session starts ==============================
+platform linux -- Python 3.10.6, pytest-7.4.0, pluggy-1.2.0 -- /home/ubuntu/venv/bin/python3
+cachedir: .pytest_cache
+rootdir: /home/ubuntu/repos/cellxgene-census/api/python/cellxgene_census
+configfile: pyproject.toml
+plugins: requests-mock-1.11.0
+collecting ... collected 180 items / 111 deselected / 69 selected
+
+test_acceptance.py::test_load_axes[homo_sapiens] PASSED                  [  1%]
+test_acceptance.py::test_load_axes[mus_musculus] PASSED                  [  2%]
+test_acceptance.py::test_incremental_read_obs[2-None-homo_sapiens] PASSED [  4%]
+test_acceptance.py::test_incremental_read_obs[2-None-mus_musculus] PASSED [  5%]
+test_acceptance.py::test_incremental_read_obs[None-ctx_config1-homo_sapiens] PASSED [  7%]
+test_acceptance.py::test_incremental_read_obs[None-ctx_config1-mus_musculus] PASSED [  8%]
+test_acceptance.py::test_incremental_read_var[2-None-homo_sapiens] PASSED [ 10%]
+test_acceptance.py::test_incremental_read_var[2-None-mus_musculus] PASSED [ 11%]
+test_acceptance.py::test_incremental_read_var[None-ctx_config1-homo_sapiens] PASSED [ 13%]
+test_acceptance.py::test_incremental_read_var[None-ctx_config1-mus_musculus] PASSED [ 14%]
+test_acceptance.py::test_incremental_read_X[2-None-homo_sapiens] PASSED  [ 15%]
+test_acceptance.py::test_incremental_read_X[2-None-mus_musculus] PASSED  [ 17%]
+test_acceptance.py::test_incremental_read_X[None-ctx_config1-homo_sapiens] PASSED [ 18%]
+test_acceptance.py::test_incremental_read_X[None-ctx_config1-mus_musculus] PASSED [ 20%]
+test_acceptance.py::test_incremental_read_X[None-ctx_config2-homo_sapiens] PASSED [ 21%]
+test_acceptance.py::test_incremental_read_X[None-ctx_config2-mus_musculus] PASSED [ 23%]
+test_acceptance.py::test_incremental_query[2-tissue=='aorta'-homo_sapiens] PASSED [ 24%]
+test_acceptance.py::test_incremental_query[2-tissue=='aorta'-mus_musculus] PASSED [ 26%]
+test_acceptance.py::test_incremental_query[2-tissue=='brain'-homo_sapiens] PASSED [ 27%]
+test_acceptance.py::test_incremental_query[2-tissue=='brain'-mus_musculus] PASSED [ 28%]
+test_acceptance.py::test_incremental_query[None-tissue=='aorta'-homo_sapiens] PASSED [ 30%]
+test_acceptance.py::test_incremental_query[None-tissue=='aorta'-mus_musculus] PASSED [ 31%]
+test_acceptance.py::test_incremental_query[None-tissue=='brain'-homo_sapiens] PASSED [ 33%]
+test_acceptance.py::test_incremental_query[None-tissue=='brain'-mus_musculus] PASSED [ 34%]
+test_acceptance.py::test_get_anndata[tissue=='aorta'-None-ctx_config0-homo_sapiens] PASSED [ 36%]
+test_acceptance.py::test_get_anndata[tissue=='aorta'-None-ctx_config0-mus_musculus] PASSED [ 37%]
+test_acceptance.py::test_get_anndata[First 10K cells-homo_sapiens] PASSED [ 39%]
+test_acceptance.py::test_get_anndata[First 10K cells-mus_musculus] PASSED [ 40%]
+test_acceptance.py::test_get_anndata[First 100K cells-homo_sapiens] PASSED [ 42%]
+test_acceptance.py::test_get_anndata[First 100K cells-mus_musculus] PASSED [ 43%]
+test_acceptance.py::test_get_anndata[First 250K cells-homo_sapiens] PASSED [ 44%]
+test_acceptance.py::test_get_anndata[First 250K cells-mus_musculus] PASSED [ 46%]
+test_acceptance.py::test_get_anndata[First 500K cells-homo_sapiens] PASSED [ 47%]
+test_acceptance.py::test_get_anndata[First 500K cells-mus_musculus] PASSED [ 49%]
+test_acceptance.py::test_get_anndata[First 750K cells-homo_sapiens] PASSED [ 50%]
+test_acceptance.py::test_get_anndata[First 750K cells-mus_musculus] PASSED [ 52%]
+test_acceptance.py::test_get_anndata[First 1M cells-homo_sapiens] PASSED [ 53%]
+test_acceptance.py::test_get_anndata[First 1M cells-mus_musculus] PASSED [ 55%]
+test_acceptance.py::test_get_anndata[tissue=='brain'-None-ctx_config7-homo_sapiens] PASSED [ 56%]
+test_acceptance.py::test_get_anndata[tissue=='brain'-None-ctx_config7-mus_musculus] PASSED [ 57%]
+test_acceptance.py::test_get_anndata[cell_type=='neuron'-None-ctx_config8-homo_sapiens] PASSED [ 59%]
+test_acceptance.py::test_get_anndata[cell_type=='neuron'-None-ctx_config8-mus_musculus] PASSED [ 60%]
+test_acceptance.py::test_get_anndata[is_primary_data==True-None-ctx_config9-homo_sapiens] PASSED [ 62%]
+test_acceptance.py::test_get_anndata[is_primary_data==True-None-ctx_config9-mus_musculus] PASSED [ 63%]
+test_acceptance.py::test_get_anndata[None-None-ctx_config10-homo_sapiens] PASSED [ 65%]
+test_acceptance.py::test_get_anndata[None-None-ctx_config10-mus_musculus] PASSED [ 66%]
+test_directory.py::test_get_census_version_directory PASSED              [ 68%]
+test_directory.py::test_get_census_version_description_errors PASSED     [ 69%]
+test_directory.py::test_live_directory_contents PASSED                   [ 71%]
+test_get_anndata.py::test_get_anndata_value_filter PASSED                [ 72%]
+test_get_anndata.py::test_get_anndata_coords PASSED                      [ 73%]
+test_get_anndata.py::test_get_anndata_allows_missing_obs_or_var_filter PASSED [ 75%]
+test_get_helpers.py::test_get_experiment PASSED                          [ 76%]
+test_get_helpers.py::test_get_presence_matrix[homo_sapiens] PASSED       [ 78%]
+test_get_helpers.py::test_get_presence_matrix[mus_musculus] PASSED       [ 79%]
+test_open.py::test_open_soma_stable PASSED                               [ 81%]
+test_open.py::test_open_soma_latest PASSED                               [ 82%]
+test_open.py::test_open_soma_with_context PASSED                         [ 84%]
+test_open.py::test_open_soma_invalid_args PASSED                         [ 85%]
+test_open.py::test_open_soma_errors PASSED                               [ 86%]
+test_open.py::test_open_soma_defaults_to_latest_if_missing_stable PASSED [ 88%]
+test_open.py::test_open_soma_defaults_to_stable PASSED                   [ 89%]
+test_open.py::test_get_source_h5ad_uri PASSED                            [ 91%]
+test_open.py::test_get_source_h5ad_uri_errors PASSED                     [ 92%]
+test_open.py::test_download_source_h5ad PASSED                           [ 94%]
+test_open.py::test_download_source_h5ad_errors PASSED                    [ 95%]
+test_open.py::test_opening_census_without_anon_access_fails_with_bogus_creds PASSED [ 97%]
+test_open.py::test_can_open_with_anonymous_access PASSED                 [ 98%]
+test_util.py::test_uri_join PASSED                                       [100%]
+
+============================== slowest durations ===============================
+8331.89s call     tests/test_acceptance.py::test_get_anndata[None-None-ctx_config10-homo_sapiens]
+2755.15s call     tests/test_acceptance.py::test_get_anndata[is_primary_data==True-None-ctx_config9-homo_sapiens]
+1146.66s call     tests/test_acceptance.py::test_incremental_read_X[None-ctx_config1-homo_sapiens]
+891.72s call     tests/test_acceptance.py::test_incremental_read_X[None-ctx_config2-homo_sapiens]
+650.78s call     tests/test_acceptance.py::test_get_anndata[cell_type=='neuron'-None-ctx_config8-homo_sapiens]
+287.95s call     tests/test_acceptance.py::test_get_anndata[None-None-ctx_config10-mus_musculus]
+190.27s call     tests/test_acceptance.py::test_get_anndata[is_primary_data==True-None-ctx_config9-mus_musculus]
+118.72s call     tests/test_acceptance.py::test_incremental_read_X[None-ctx_config1-mus_musculus]
+102.51s call     tests/test_acceptance.py::test_incremental_read_X[None-ctx_config2-mus_musculus]
+55.81s call     tests/test_acceptance.py::test_get_anndata[First 1M cells-mus_musculus]
+48.63s call     tests/test_acceptance.py::test_get_anndata[First 750K cells-mus_musculus]
+43.77s call     tests/test_acceptance.py::test_get_anndata[cell_type=='neuron'-None-ctx_config8-mus_musculus]
+36.64s call     tests/test_acceptance.py::test_get_anndata[tissue=='brain'-None-ctx_config7-homo_sapiens]
+35.32s call     tests/test_acceptance.py::test_get_anndata[First 1M cells-homo_sapiens]
+34.39s call     tests/test_acceptance.py::test_get_anndata[First 500K cells-mus_musculus]
+29.83s call     tests/test_acceptance.py::test_get_anndata[First 750K cells-homo_sapiens]
+27.46s call     tests/test_acceptance.py::test_incremental_query[None-tissue=='brain'-homo_sapiens]
+23.21s call     tests/test_acceptance.py::test_get_anndata[First 500K cells-homo_sapiens]
+20.32s call     tests/test_acceptance.py::test_get_anndata[First 250K cells-mus_musculus]
+18.22s call     tests/test_acceptance.py::test_incremental_query[2-tissue=='brain'-homo_sapiens]
+16.58s call     tests/test_acceptance.py::test_get_anndata[First 250K cells-homo_sapiens]
+11.48s call     tests/test_acceptance.py::test_get_anndata[tissue=='brain'-None-ctx_config7-mus_musculus]
+10.18s call     tests/test_acceptance.py::test_incremental_query[2-tissue=='aorta'-homo_sapiens]
+9.88s call     tests/test_acceptance.py::test_get_anndata[First 100K cells-homo_sapiens]
+9.47s call     tests/test_acceptance.py::test_incremental_query[2-tissue=='brain'-mus_musculus]
+9.44s call     tests/test_acceptance.py::test_get_anndata[First 100K cells-mus_musculus]
+8.86s call     tests/test_get_anndata.py::test_get_anndata_allows_missing_obs_or_var_filter
+8.70s call     tests/test_acceptance.py::test_incremental_read_X[2-None-homo_sapiens]
+7.92s call     tests/test_acceptance.py::test_load_axes[homo_sapiens]
+7.32s call     tests/test_acceptance.py::test_incremental_query[None-tissue=='brain'-mus_musculus]
+7.22s call     tests/test_acceptance.py::test_incremental_query[None-tissue=='aorta'-homo_sapiens]
+6.99s call     tests/test_acceptance.py::test_get_anndata[tissue=='aorta'-None-ctx_config0-homo_sapiens]
+6.20s call     tests/test_directory.py::test_live_directory_contents
+5.57s call     tests/test_get_anndata.py::test_get_anndata_value_filter
+4.58s call     tests/test_acceptance.py::test_incremental_query[2-tissue=='aorta'-mus_musculus]
+4.53s call     tests/test_acceptance.py::test_get_anndata[First 10K cells-homo_sapiens]
+4.19s call     tests/test_open.py::test_get_source_h5ad_uri
+4.03s call     tests/test_get_helpers.py::test_get_presence_matrix[homo_sapiens]
+4.01s call     tests/test_acceptance.py::test_incremental_query[None-tissue=='aorta'-mus_musculus]
+3.98s call     tests/test_acceptance.py::test_get_anndata[First 10K cells-mus_musculus]
+3.48s call     tests/test_acceptance.py::test_get_anndata[tissue=='aorta'-None-ctx_config0-mus_musculus]
+3.41s call     tests/test_acceptance.py::test_incremental_read_obs[None-ctx_config1-homo_sapiens]
+2.24s call     tests/test_get_anndata.py::test_get_anndata_coords
+2.19s call     tests/test_acceptance.py::test_incremental_read_X[2-None-mus_musculus]
+2.17s call     tests/test_get_helpers.py::test_get_presence_matrix[mus_musculus]
+2.04s call     tests/test_acceptance.py::test_load_axes[mus_musculus]
+2.01s call     tests/test_open.py::test_download_source_h5ad
+1.38s call     tests/test_acceptance.py::test_incremental_read_obs[2-None-homo_sapiens]
+1.25s call     tests/test_acceptance.py::test_incremental_read_obs[None-ctx_config1-mus_musculus]
+1.24s call     tests/test_acceptance.py::test_incremental_read_obs[2-None-mus_musculus]
+1.16s call     tests/test_acceptance.py::test_incremental_read_var[2-None-mus_musculus]
+1.15s call     tests/test_acceptance.py::test_incremental_read_var[None-ctx_config1-mus_musculus]
+1.12s call     tests/test_acceptance.py::test_incremental_read_var[2-None-homo_sapiens]
+1.08s call     tests/test_acceptance.py::test_incremental_read_var[None-ctx_config1-homo_sapiens]
+1.01s setup    tests/test_open.py::test_download_source_h5ad_errors
+1.01s setup    tests/test_open.py::test_download_source_h5ad
+0.90s call     tests/test_open.py::test_get_source_h5ad_uri_errors
+0.68s call     tests/test_open.py::test_open_soma_stable
+0.64s call     tests/test_open.py::test_open_soma_with_context
+0.56s call     tests/test_get_helpers.py::test_get_experiment
+0.36s call     tests/test_open.py::test_open_soma_defaults_to_latest_if_missing_stable
+0.36s setup    tests/test_get_anndata.py::test_get_anndata_allows_missing_obs_or_var_filter
+0.36s setup    tests/test_get_anndata.py::test_get_anndata_coords
+0.35s setup    tests/test_get_anndata.py::test_get_anndata_value_filter
+0.34s call     tests/test_open.py::test_open_soma_latest
+0.32s call     tests/test_directory.py::test_get_census_version_description_errors
+0.32s call     tests/test_open.py::test_can_open_with_anonymous_access
+0.25s call     tests/test_open.py::test_opening_census_without_anon_access_fails_with_bogus_creds
+0.03s setup    tests/test_directory.py::test_get_census_version_directory
+0.03s call     tests/test_directory.py::test_get_census_version_directory
+0.02s teardown tests/test_acceptance.py::test_get_anndata[cell_type=='neuron'-None-ctx_config8-homo_sapiens]
+0.02s teardown tests/test_acceptance.py::test_get_anndata[None-None-ctx_config10-homo_sapiens]
+0.01s teardown tests/test_acceptance.py::test_get_anndata[is_primary_data==True-None-ctx_config9-homo_sapiens]
+0.01s setup    tests/test_acceptance.py::test_get_anndata[is_primary_data==True-None-ctx_config9-mus_musculus]
+0.01s setup    tests/test_acceptance.py::test_get_anndata[None-None-ctx_config10-mus_musculus]
+0.01s setup    tests/test_acceptance.py::test_get_anndata[cell_type=='neuron'-None-ctx_config8-mus_musculus]
+
+(131 durations < 0.005s hidden.  Use -vv to show these durations.)
+=============== 69 passed, 111 deselected in 15040.59s (4:10:40) ===============
+```
+
 ## 2023-05-16
 
 - Host: EC2 instance type: `r6id.x32xlarge`, all nvme mounted as swap.

--- a/api/python/cellxgene_census/tests/test_acceptance.py
+++ b/api/python/cellxgene_census/tests/test_acceptance.py
@@ -93,7 +93,6 @@ def test_incremental_read_obs(organism: str, stop_after: Optional[int], ctx_conf
         
 @pytest.mark.live_corpus
 @pytest.mark.parametrize("organism", ["homo_sapiens", "mus_musculus"])
-@pytest.mark.parametrize("stop_after", [2, pytest.param(None, marks=pytest.mark.expensive)])
 @pytest.mark.parametrize(
     ("stop_after", "ctx_config"),
     [

--- a/api/python/cellxgene_census/tests/test_acceptance.py
+++ b/api/python/cellxgene_census/tests/test_acceptance.py
@@ -75,7 +75,7 @@ def table_iter_is_ok(tbl_iter: Iterator[pa.Table], stop_after: Optional[int] = 2
     [
         pytest.param(2, None),
         pytest.param(None, DEFAULT_TILEDB_CONFIGURATION, marks=pytest.mark.expensive),
-    ]
+    ],
 )
 def test_incremental_read_obs(organism: str, stop_after: Optional[int], ctx_config: Optional[Dict[str, Any]]) -> None:
     """Verify that obs, var and X[raw] can be read incrementally, i.e., in chunks"""
@@ -86,11 +86,10 @@ def test_incremental_read_obs(organism: str, stop_after: Optional[int], ctx_conf
     context = make_context("latest", ctx_config)
     with cellxgene_census.open_soma(census_version="latest", context=context) as census:
         assert table_iter_is_ok(
-            census["census_data"][organism].obs.read(column_names=["soma_joinid", "tissue"]),
-            stop_after=stop_after
+            census["census_data"][organism].obs.read(column_names=["soma_joinid", "tissue"]), stop_after=stop_after
         )
-        
-        
+
+
 @pytest.mark.live_corpus
 @pytest.mark.parametrize("organism", ["homo_sapiens", "mus_musculus"])
 @pytest.mark.parametrize(
@@ -98,7 +97,7 @@ def test_incremental_read_obs(organism: str, stop_after: Optional[int], ctx_conf
     [
         pytest.param(2, None),
         pytest.param(None, DEFAULT_TILEDB_CONFIGURATION, marks=pytest.mark.expensive),
-    ]
+    ],
 )
 def test_incremental_read_var(organism: str, stop_after: Optional[int], ctx_config: Optional[Dict[str, Any]]) -> None:
     """Verify that var can be read incrementally, i.e., in chunks"""
@@ -110,7 +109,7 @@ def test_incremental_read_var(organism: str, stop_after: Optional[int], ctx_conf
     with cellxgene_census.open_soma(census_version="latest", context=context) as census:
         assert table_iter_is_ok(
             census["census_data"][organism].ms["RNA"].var.read(column_names=["soma_joinid", "feature_id"]),
-            stop_after=stop_after
+            stop_after=stop_after,
         )
 
 
@@ -121,8 +120,8 @@ def test_incremental_read_var(organism: str, stop_after: Optional[int], ctx_conf
     [
         pytest.param(2, None),
         pytest.param(None, DEFAULT_TILEDB_CONFIGURATION, marks=pytest.mark.expensive),
-        pytest.param(None, {"soma.init_buffer_bytes": 4 * 1024**3}, marks=pytest.mark.expensive)
-    ]
+        pytest.param(None, {"soma.init_buffer_bytes": 4 * 1024**3}, marks=pytest.mark.expensive),
+    ],
 )
 def test_incremental_read_X(organism: str, stop_after: Optional[int], ctx_config: Optional[Dict[str, Any]]) -> None:
     """Verify that obs, var and X[raw] can be read incrementally, i.e., in chunks"""
@@ -131,8 +130,7 @@ def test_incremental_read_X(organism: str, stop_after: Optional[int], ctx_config
     context = make_context("latest", ctx_config)
     with cellxgene_census.open_soma(census_version="latest", context=context) as census:
         assert table_iter_is_ok(
-            census["census_data"][organism].ms["RNA"].X["raw"].read().tables(), 
-            stop_after=stop_after
+            census["census_data"][organism].ms["RNA"].X["raw"].read().tables(), stop_after=stop_after
         )
 
 

--- a/api/python/cellxgene_census/tests/test_acceptance.py
+++ b/api/python/cellxgene_census/tests/test_acceptance.py
@@ -70,13 +70,20 @@ def table_iter_is_ok(tbl_iter: Iterator[pa.Table], stop_after: Optional[int] = 2
 
 @pytest.mark.live_corpus
 @pytest.mark.parametrize("organism", ["homo_sapiens", "mus_musculus"])
-@pytest.mark.parametrize("stop_after", [2, pytest.param(None, marks=pytest.mark.expensive)])
+@pytest.mark.parametrize(
+    ("stop_after", "ctx_config"),
+    [
+        pytest.param(2, None),
+        pytest.param(None, DEFAULT_TILEDB_CONFIGURATION, marks=pytest.mark.expensive),
+    ]
+)
 def test_incremental_read_obs(organism: str, stop_after: Optional[int], ctx_config: Optional[Dict[str, Any]]) -> None:
     """Verify that obs, var and X[raw] can be read incrementally, i.e., in chunks"""
 
-    # open census with a small (default) TileDB buffer size, which reduces
+    # ctx_config=None open census with a small (default) TileDB buffer size, which reduces
     # memory use, and makes it feasible to run in a GHA.
-    context = make_context("latest")
+    ctx_config = ctx_config or {}
+    context = make_context("latest", ctx_config)
     with cellxgene_census.open_soma(census_version="latest", context=context) as census:
         assert table_iter_is_ok(
             census["census_data"][organism].obs.read(column_names=["soma_joinid", "tissue"]),
@@ -87,12 +94,20 @@ def test_incremental_read_obs(organism: str, stop_after: Optional[int], ctx_conf
 @pytest.mark.live_corpus
 @pytest.mark.parametrize("organism", ["homo_sapiens", "mus_musculus"])
 @pytest.mark.parametrize("stop_after", [2, pytest.param(None, marks=pytest.mark.expensive)])
+@pytest.mark.parametrize(
+    ("stop_after", "ctx_config"),
+    [
+        pytest.param(2, None),
+        pytest.param(None, DEFAULT_TILEDB_CONFIGURATION, marks=pytest.mark.expensive),
+    ]
+)
 def test_incremental_read_var(organism: str, stop_after: Optional[int], ctx_config: Optional[Dict[str, Any]]) -> None:
-    """Verify that obs, var and X[raw] can be read incrementally, i.e., in chunks"""
+    """Verify that var can be read incrementally, i.e., in chunks"""
 
-    # open census with a small (default) TileDB buffer size, which reduces
+    # ctx_config=None open census with a small (default) TileDB buffer size, which reduces
     # memory use, and makes it feasible to run in a GHA.
-    context = make_context("latest")
+    ctx_config = ctx_config or {}
+    context = make_context("latest", ctx_config)
     with cellxgene_census.open_soma(census_version="latest", context=context) as census:
         assert table_iter_is_ok(
             census["census_data"][organism].ms["RNA"].var.read(column_names=["soma_joinid", "feature_id"]),

--- a/api/r/cellxgene.census/tests/README.md
+++ b/api/r/cellxgene.census/tests/README.md
@@ -2,7 +2,7 @@
 
 This directory contains tests of the `cellxgene.census` R package API, _and_ the use of the API on the live "corpus", i.e., data in the public Census S3 bucket. The tests use the R package `tessthat`.
 
-In addition, a set of acceptance (expensive) tests are available and `testthat` does not run them by default (see [section below](#Acceptance-(expensive)-tests)).
+In addition, a set of acceptance (expensive) tests are available and `testthat` does not run them by default (see [section below](#Acceptance-expensive-tests)).
 
 Tests can be run in the usual manner. First, ensure you have `cellxgene-census` and `testthat` installed, e.g., from the top-level repo directory:
 

--- a/api/r/cellxgene.census/tests/README.md
+++ b/api/r/cellxgene.census/tests/README.md
@@ -1,0 +1,205 @@
+# Test README
+
+This directory contains tests of the `cellxgene.census` R package API, _and_ the use of the API on the live "corpus", i.e., data in the public Census S3 bucket. The tests use the R package `tessthat`.
+
+In addition, a set of acceptance (expensive) tests are available and `testthat` does not run them by default (see [section below](#Acceptance-(expensive)-tests)).
+
+Tests can be run in the usual manner. First, ensure you have `cellxgene-census` and `testthat` installed, e.g., from the top-level repo directory:
+
+Then run the tests from R in the repo root folder:
+
+```r
+library("testthat")
+library("cellxgene.census")
+test_dir("./api/r/cellxgene.census/tests/")
+```
+
+# Acceptance (expensive) tests
+
+These tests are periodically run, and are not part of CI due to their overhead.
+
+These tests use a modified `Reporter` from `testthat` to record running times of each test in a `csv` file. To run the test execute the following command:
+
+```
+Rscript ./api/r/cellxgene.census/tests/testthat/acceptance-tests-run-script.R > stdout.txt
+```
+
+This command will result in two files:
+
+- `stdout.txt` with the test progress logs.
+- `acceptance-tests-logs-[YYY]-[MM]-[DD].csv` with the running times and test outputs. 
+
+When run, please record the results in this file (below) and commit the change to git. Please include the following information:
+
+- date
+- config:
+  - EC2 instance type and any system config (i.e., swap)
+  - host and OS as reported by `uname -a`
+  - R session info `library("cellxgene.census"); sessionInfo()`
+  - The Census version used for the test (i.e., the version aliased as `latest`). This can be easily captured using `cellxgene.census::get_census_version_description('latest')`
+- any run notes
+- full output of:
+  - `stdout.txt`
+  - `acceptance-tests-logs-[YYY]-[MM]-[DD].csv`
+
+## 2023-06-23
+
+- Host: EC2 instance type: `r6id.x32xlarge`, all nvme mounted as swap.
+- Uname: Linux ip-172-31-62-52 5.19.0-1026-aws #27~22.04.1-Ubuntu SMP Mon May 22 15:57:16 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
+- Census version
+
+```
+> cellxgene.census::get_census_version_description('latest')
+$release_date
+[1] ""
+
+$release_build
+[1] "2023-06-20"
+
+$soma.uri
+[1] "s3://cellxgene-data-public/cell-census/2023-06-20/soma/"
+
+$soma.s3_region
+[1] "us-west-2"
+
+$h5ads.uri
+[1] "s3://cellxgene-data-public/cell-census/2023-06-20/h5ads/"
+
+$h5ads.s3_region
+[1] "us-west-2"
+
+$alias
+[1] "latest"
+
+$census_version
+[1] "latest"
+```
+
+- R session info 
+
+```
+> library("cellxgene.census"); sessionInfo()
+R version 4.3.0 (2023-04-21)
+Platform: x86_64-pc-linux-gnu (64-bit)
+Running under: Ubuntu 22.04.2 LTS
+
+Matrix products: default
+BLAS:   /usr/lib/x86_64-linux-gnu/blas/libblas.so.3.10.0 
+LAPACK: /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.10.0
+
+locale:
+ [1] LC_CTYPE=C.UTF-8       LC_NUMERIC=C           LC_TIME=C.UTF-8       
+ [4] LC_COLLATE=C.UTF-8     LC_MONETARY=C.UTF-8    LC_MESSAGES=C.UTF-8   
+ [7] LC_PAPER=C.UTF-8       LC_NAME=C              LC_ADDRESS=C          
+[10] LC_TELEPHONE=C         LC_MEASUREMENT=C.UTF-8 LC_IDENTIFICATION=C   
+
+time zone: America/Los_Angeles
+tzcode source: system (glibc)
+
+attached base packages:
+[1] stats     graphics  grDevices utils     datasets  methods   base     
+
+other attached packages:
+[1] cellxgene.census_0.0.0.9000
+
+loaded via a namespace (and not attached):
+ [1] vctrs_0.6.3           httr_1.4.6            cli_3.6.1            
+ [4] tiledbsoma_0.0.0.9028 rlang_1.1.1           purrr_1.0.1          
+ [7] assertthat_0.2.1      data.table_1.14.8     jsonlite_1.8.5       
+[10] glue_1.6.2            bit_4.0.5             triebeard_0.4.1      
+[13] grid_4.3.0            RcppSpdlog_0.0.13     base64enc_0.1-3      
+[16] lifecycle_1.0.3       compiler_4.3.0        fs_1.6.2             
+[19] Rcpp_1.0.10           aws.s3_0.3.21         lattice_0.21-8       
+[22] digest_0.6.31         R6_2.5.1              tidyselect_1.2.0     
+[25] curl_5.0.1            magrittr_2.0.3        urltools_1.7.3       
+[28] Matrix_1.5-4.1        tools_4.3.0           bit64_4.0.5          
+[31] aws.signature_0.6.0   spdl_0.0.5            arrow_12.0.1         
+[34] xml2_1.3.4     
+
+```
+
+- `stdout.txt`
+
+```
+START TEST ( 2023-06-23 13:55:52.324647 ):  test_load_obs_human 
+END TEST ( 2023-06-23 13:55:59.362807 ):  test_load_obs_human 
+START TEST ( 2023-06-23 13:55:59.364576 ):  test_load_var_human 
+END TEST ( 2023-06-23 13:56:00.939187 ):  test_load_var_human 
+START TEST ( 2023-06-23 13:56:00.941131 ):  test_load_obs_mouse 
+END TEST ( 2023-06-23 13:56:03.004462 ):  test_load_obs_mouse 
+START TEST ( 2023-06-23 13:56:03.006694 ):  test_load_var_mouse 
+END TEST ( 2023-06-23 13:56:04.727943 ):  test_load_var_mouse 
+START TEST ( 2023-06-23 13:56:04.730105 ):  test_incremental_read_obs_human 
+END TEST ( 2023-06-23 13:56:10.508174 ):  test_incremental_read_obs_human 
+START TEST ( 2023-06-23 13:56:10.51139 ):  test_incremental_read_var_human 
+END TEST ( 2023-06-23 13:56:12.073684 ):  test_incremental_read_var_human 
+START TEST ( 2023-06-23 13:56:12.07612 ):  test_incremental_read_X_human 
+END TEST ( 2023-06-23 14:17:46.233498 ):  test_incremental_read_X_human 
+START TEST ( 2023-06-23 14:17:46.236098 ):  test_incremental_read_X_human-large-buffer-size 
+END TEST ( 2023-06-23 14:42:27.219841 ):  test_incremental_read_X_human-large-buffer-size 
+START TEST ( 2023-06-23 14:42:27.313921 ):  test_incremental_read_obs_mouse 
+END TEST ( 2023-06-23 14:42:35.792303 ):  test_incremental_read_obs_mouse 
+START TEST ( 2023-06-23 14:42:35.825136 ):  test_incremental_read_var_mouse 
+END TEST ( 2023-06-23 14:44:48.181343 ):  test_incremental_read_var_mouse 
+START TEST ( 2023-06-23 14:44:48.225299 ):  test_incremental_read_X_mouse 
+END TEST ( 2023-06-23 14:46:40.709836 ):  test_incremental_read_X_mouse 
+START TEST ( 2023-06-23 14:46:40.712315 ):  test_incremental_read_X_mouse-large-buffer-size 
+END TEST ( 2023-06-23 14:48:02.087424 ):  test_incremental_read_X_mouse-large-buffer-size 
+START TEST ( 2023-06-23 14:48:02.091451 ):  test_incremental_query 
+END TEST ( 2023-06-23 14:48:02.100564 ):  test_incremental_query 
+START TEST ( 2023-06-23 14:48:02.102893 ):  test_seurat_small-query 
+END TEST ( 2023-06-23 14:48:48.744465 ):  test_seurat_small-query 
+START TEST ( 2023-06-23 14:48:48.746438 ):  test_seurat_10K-cells-human 
+END TEST ( 2023-06-23 14:49:01.11209 ):  test_seurat_10K-cells-human 
+START TEST ( 2023-06-23 14:49:01.114074 ):  test_seurat_100K-cells-human 
+END TEST ( 2023-06-23 14:49:51.088361 ):  test_seurat_100K-cells-human 
+START TEST ( 2023-06-23 14:49:51.090358 ):  test_seurat_250K-cells-human 
+END TEST ( 2023-06-23 14:51:32.084494 ):  test_seurat_250K-cells-human 
+START TEST ( 2023-06-23 14:51:32.086453 ):  test_seurat_500K-cells-human 
+END TEST ( 2023-06-23 14:55:04.211365 ):  test_seurat_500K-cells-human 
+START TEST ( 2023-06-23 14:55:04.213284 ):  test_seurat_750K-cells-human 
+END TEST ( 2023-06-23 15:00:02.888813 ):  test_seurat_750K-cells-human 
+START TEST ( 2023-06-23 15:00:02.890819 ):  test_seurat_1M-cells-human 
+END TEST ( 2023-06-23 15:00:54.993723 ):  test_seurat_1M-cells-human 
+START TEST ( 2023-06-23 15:00:54.996504 ):  test_seurat_common-tissue 
+END TEST ( 2023-06-23 15:05:05.376396 ):  test_seurat_common-tissue 
+START TEST ( 2023-06-23 15:05:05.378534 ):  test_seurat_common-tissue-large-buffer-size 
+END TEST ( 2023-06-23 15:09:13.780464 ):  test_seurat_common-tissue-large-buffer-size 
+START TEST ( 2023-06-23 15:09:13.782572 ):  test_seurat_common-cell-type 
+END TEST ( 2023-06-23 15:24:43.865822 ):  test_seurat_common-cell-type 
+START TEST ( 2023-06-23 15:24:43.867832 ):  test_seurat_common-cell-type-large-buffer-size 
+END TEST ( 2023-06-23 16:56:58.016858 ):  test_seurat_common-cell-type-large-buffer-size 
+START TEST ( 2023-06-23 16:56:58.020263 ):  test_seurat_whole-enchilada-large-buffer-size 
+END TEST ( 2023-06-23 16:56:58.025497 ):  test_seurat_whole-enchilada-large-buffer-size 
+```
+
+- `acceptance-tests-logs-2023-06-23.csv `
+
+```
+test,user,system,real,test_result
+test_load_obs_human,18.366,101.34,7.037,expect_true(nrow(obs_df) > 0): expectation_success: nrow(obs_df) > 0 is not TRUE 
+test_load_var_human,0.369,0.530999999999992,1.569,expect_true(nrow(var_df) > 0): expectation_success: nrow(var_df) > 0 is not TRUE 
+test_load_obs_mouse,2.011,6.202,2.062,expect_true(nrow(obs_df) > 0): expectation_success: nrow(obs_df) > 0 is not TRUE 
+test_load_var_mouse,0.417999999999999,0.486000000000004,1.721,expect_true(nrow(var_df) > 0): expectation_success: nrow(var_df) > 0 is not TRUE 
+test_incremental_read_obs_human,18.411,94.142,5.777,expect_true(table_iter_is_ok(obs_iter)): expectation_success: table_iter_is_ok(obs_iter) is not TRUE 
+test_incremental_read_var_human,0.454999999999998,0.531000000000006,1.561,expect_true(table_iter_is_ok(var_iter)): expectation_success: table_iter_is_ok(var_iter) is not TRUE 
+test_incremental_read_X_human,8193.649,14613.005,1294.156,expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables()): expectation_success:  ; expect_true(table_iter_is_ok(X_iter)): expectation_success: table_iter_is_ok(X_iter) is not TRUE 
+test_incremental_read_X_human-large-buffer-size,8091.321,43302.612,1480.899,expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables()): expectation_success:  ; expect_true(table_iter_is_ok(X_iter)): expectation_success: table_iter_is_ok(X_iter) is not TRUE 
+test_incremental_read_obs_mouse,2.22500000000036,13.4630000000034,8.45900000000029,expect_true(table_iter_is_ok(obs_iter)): expectation_success: table_iter_is_ok(obs_iter) is not TRUE 
+test_incremental_read_var_mouse,0.7549999999992,128.547999999995,132.348,expect_true(table_iter_is_ok(var_iter)): expectation_success: table_iter_is_ok(var_iter) is not TRUE 
+test_incremental_read_X_mouse,928.090000000002,1636.642,112.482,expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables()): expectation_success:  ; expect_true(table_iter_is_ok(X_iter)): expectation_success: table_iter_is_ok(X_iter) is not TRUE 
+test_incremental_read_X_mouse-large-buffer-size,899.965,1779.616,81.373,expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables()): expectation_success:  ; expect_true(table_iter_is_ok(X_iter)): expectation_success: table_iter_is_ok(X_iter) is not TRUE 
+test_incremental_query,0.00500000000101863,0.000999999996565748,0.00800000000026557,expect_true(TRUE): expectation_success: TRUE is not TRUE 
+test_seurat_small-query,26.2459999999992,105.765999999996,46.6410000000001,test_seurat(test_args): expectation_warning: Iteration results cannot be concatenated on its entirety because array has non-zero elements greater than '.Machine$integer.max'. ; test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_10K-cells-human,8.78700000000026,9.39099999999598,12.3649999999998,test_seurat(test_args): expectation_warning: Iteration results cannot be concatenated on its entirety because array has non-zero elements greater than '.Machine$integer.max'. ; test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_100K-cells-human,52.6959999999999,51.7980000000025,49.973,test_seurat(test_args): expectation_warning: Iteration results cannot be concatenated on its entirety because array has non-zero elements greater than '.Machine$integer.max'. ; test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_250K-cells-human,117.172999999999,100.030000000006,100.993,test_seurat(test_args): expectation_warning: Iteration results cannot be concatenated on its entirety because array has non-zero elements greater than '.Machine$integer.max'. ; test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_500K-cells-human,236.339,191.728999999999,212.124,test_seurat(test_args): expectation_warning: Iteration results cannot be concatenated on its entirety because array has non-zero elements greater than '.Machine$integer.max'. ; test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_750K-cells-human,334.721999999998,264.296999999999,298.675,test_seurat(test_args): expectation_warning: Iteration results cannot be concatenated on its entirety because array has non-zero elements greater than '.Machine$integer.max'. ; test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_1M-cells-human,156.661,246.656000000003,52.1020000000003,test_seurat(test_args): expectation_warning: Iteration results cannot be concatenated on its entirety because array has non-zero elements greater than '.Machine$integer.max'. ; test_seurat(test_args): Error: Error in `vec_to_Array(x, type)`: long vectors not supported yet: memory.c:3888 
+test_seurat_common-tissue,392.353999999999,277.388999999996,250.379,test_seurat(test_args): expectation_warning: Iteration results cannot be concatenated on its entirety because array has non-zero elements greater than '.Machine$integer.max'. ; test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_common-tissue-large-buffer-size,379.781999999999,300.778000000006,248.401000000001,test_seurat(test_args): expectation_warning: Iteration results cannot be concatenated on its entirety because array has non-zero elements greater than '.Machine$integer.max'. ; test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_common-cell-type,3346.826,11816.851,930.083,test_seurat(test_args): expectation_warning: Iteration results cannot be concatenated on its entirety because array has non-zero elements greater than '.Machine$integer.max'. ; test_seurat(test_args): Error: Error in `vec_to_Array(x, type)`: long vectors not supported yet: memory.c:3888 
+test_seurat_common-cell-type-large-buffer-size,3437.291,28305.89,5534.148,test_seurat(test_args): expectation_warning: Iteration results cannot be concatenated on its entirety because array has non-zero elements greater than '.Machine$integer.max'. ; test_seurat(test_args): Error: Error in `vec_to_Array(x, type)`: long vectors not supported yet: memory.c:3888 
+test_seurat_whole-enchilada-large-buffer-size,0.00399999999717693,0.00099999998928979,0.00500000000101863,expect_true(TRUE): expectation_success: TRUE is not TRUE 
+```

--- a/api/r/cellxgene.census/tests/README.md
+++ b/api/r/cellxgene.census/tests/README.md
@@ -43,10 +43,10 @@ When run, please record the results in this file (below) and commit the change t
   - `acceptance-tests-logs-[YYY]-[MM]-[DD].csv`
 
 
-## 2023-06-29
+## 2023-07-02
 
 - Host: EC2 instance type: `r6id.x32xlarge`, all nvme mounted as swap.
-- Uname: Linux ip-172-31-62-52 5.19.0-1027-aws #28~22.04.1-Ubuntu SMP Wed May 31 18:30:36 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
+- Uname: Linux ip-172-31-62-52 5.19.0-1028-aws #29~22.04.1-Ubuntu SMP Tue Jun 20 19:12:11 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
 - Census version
 
 ```
@@ -122,96 +122,96 @@ loaded via a namespace (and not attached):
 - `stdout.txt`
 
 ```
-START TEST ( 2023-06-28 13:07:31.895118 ):  test_load_obs_human 
-END TEST ( 2023-06-28 13:07:39.308527 ):  test_load_obs_human 
-START TEST ( 2023-06-28 13:07:39.310306 ):  test_load_var_human 
-END TEST ( 2023-06-28 13:07:40.99671 ):  test_load_var_human 
-START TEST ( 2023-06-28 13:07:40.998601 ):  test_load_obs_mouse 
-END TEST ( 2023-06-28 13:07:43.292537 ):  test_load_obs_mouse 
-START TEST ( 2023-06-28 13:07:43.294842 ):  test_load_var_mouse 
-END TEST ( 2023-06-28 13:07:45.002476 ):  test_load_var_mouse 
-START TEST ( 2023-06-28 13:07:45.004729 ):  test_incremental_read_obs_human 
-END TEST ( 2023-06-28 13:07:50.491426 ):  test_incremental_read_obs_human 
-START TEST ( 2023-06-28 13:07:50.493703 ):  test_incremental_read_var_human 
-END TEST ( 2023-06-28 13:07:52.038702 ):  test_incremental_read_var_human 
-START TEST ( 2023-06-28 13:07:52.041194 ):  test_incremental_read_X_human 
-END TEST ( 2023-06-28 13:29:33.990447 ):  test_incremental_read_X_human 
-START TEST ( 2023-06-28 13:29:33.993099 ):  test_incremental_read_X_human-large-buffer-size 
-END TEST ( 2023-06-28 13:56:46.292904 ):  test_incremental_read_X_human-large-buffer-size 
-START TEST ( 2023-06-28 13:56:46.410884 ):  test_incremental_read_obs_mouse 
-END TEST ( 2023-06-28 13:56:54.468978 ):  test_incremental_read_obs_mouse 
-START TEST ( 2023-06-28 13:56:54.496171 ):  test_incremental_read_var_mouse 
-END TEST ( 2023-06-28 13:56:57.260737 ):  test_incremental_read_var_mouse 
-START TEST ( 2023-06-28 13:56:57.299614 ):  test_incremental_read_X_mouse 
-END TEST ( 2023-06-28 14:00:33.340603 ):  test_incremental_read_X_mouse 
-START TEST ( 2023-06-28 14:00:33.342839 ):  test_incremental_read_X_mouse-large-buffer-size 
-END TEST ( 2023-06-28 14:02:03.251537 ):  test_incremental_read_X_mouse-large-buffer-size 
-START TEST ( 2023-06-28 14:02:03.253954 ):  test_incremental_query_human_brain 
-END TEST ( 2023-06-28 14:03:10.796619 ):  test_incremental_query_human_brain 
-START TEST ( 2023-06-28 14:03:10.79851 ):  test_incremental_query_human_aorta 
-END TEST ( 2023-06-28 14:03:23.883367 ):  test_incremental_query_human_aorta 
-START TEST ( 2023-06-28 14:03:23.885332 ):  test_incremental_query_mouse_brain 
-END TEST ( 2023-06-28 14:03:35.250481 ):  test_incremental_query_mouse_brain 
-START TEST ( 2023-06-28 14:03:35.252468 ):  test_incremental_query_mouse_aorta 
-END TEST ( 2023-06-28 14:03:42.035149 ):  test_incremental_query_mouse_aorta 
-START TEST ( 2023-06-28 14:03:42.037484 ):  test_seurat_small-query 
-END TEST ( 2023-06-28 14:04:04.055966 ):  test_seurat_small-query 
-START TEST ( 2023-06-28 14:04:04.057835 ):  test_seurat_10K-cells-human 
-END TEST ( 2023-06-28 14:04:17.078379 ):  test_seurat_10K-cells-human 
-START TEST ( 2023-06-28 14:04:17.080181 ):  test_seurat_100K-cells-human 
-END TEST ( 2023-06-28 14:05:08.98193 ):  test_seurat_100K-cells-human 
-START TEST ( 2023-06-28 14:05:08.983845 ):  test_seurat_250K-cells-human 
-END TEST ( 2023-06-28 14:06:58.356763 ):  test_seurat_250K-cells-human 
-START TEST ( 2023-06-28 14:06:58.358616 ):  test_seurat_500K-cells-human 
-END TEST ( 2023-06-28 14:10:39.413578 ):  test_seurat_500K-cells-human 
-START TEST ( 2023-06-28 14:10:39.415487 ):  test_seurat_750K-cells-human 
-END TEST ( 2023-06-28 14:15:51.340092 ):  test_seurat_750K-cells-human 
-START TEST ( 2023-06-28 14:15:51.341954 ):  test_seurat_1M-cells-human 
-END TEST ( 2023-06-28 14:16:42.491952 ):  test_seurat_1M-cells-human 
-START TEST ( 2023-06-28 14:16:42.494254 ):  test_seurat_common-tissue 
-END TEST ( 2023-06-28 14:20:43.831188 ):  test_seurat_common-tissue 
-START TEST ( 2023-06-28 14:20:43.833142 ):  test_seurat_common-tissue-large-buffer-size 
-END TEST ( 2023-06-28 14:24:50.548616 ):  test_seurat_common-tissue-large-buffer-size 
-START TEST ( 2023-06-28 14:24:50.550572 ):  test_seurat_common-cell-type 
-END TEST ( 2023-06-28 14:41:30.949797 ):  test_seurat_common-cell-type 
-START TEST ( 2023-06-28 14:41:30.952931 ):  test_seurat_common-cell-type-large-buffer-size 
-END TEST ( 2023-06-28 16:01:33.389666 ):  test_seurat_common-cell-type-large-buffer-size 
-START TEST ( 2023-06-28 16:01:33.393631 ):  test_seurat_whole-enchilada-large-buffer-size 
-END TEST ( 2023-06-28 16:01:33.398993 ):  test_seurat_whole-enchilada-large-buffer-size
+START TEST ( 2023-07-02 14:46:28.791692 ):  test_load_obs_human 
+END TEST ( 2023-07-02 14:46:35.845693 ):  test_load_obs_human 
+START TEST ( 2023-07-02 14:46:35.847513 ):  test_load_var_human 
+END TEST ( 2023-07-02 14:46:37.550566 ):  test_load_var_human 
+START TEST ( 2023-07-02 14:46:37.552496 ):  test_load_obs_mouse 
+END TEST ( 2023-07-02 14:46:39.540367 ):  test_load_obs_mouse 
+START TEST ( 2023-07-02 14:46:39.542638 ):  test_load_var_mouse 
+END TEST ( 2023-07-02 14:46:41.049362 ):  test_load_var_mouse 
+START TEST ( 2023-07-02 14:46:41.051673 ):  test_incremental_read_obs_human 
+END TEST ( 2023-07-02 14:46:46.651326 ):  test_incremental_read_obs_human 
+START TEST ( 2023-07-02 14:46:46.653535 ):  test_incremental_read_var_human 
+END TEST ( 2023-07-02 14:46:48.216871 ):  test_incremental_read_var_human 
+START TEST ( 2023-07-02 14:46:48.219266 ):  test_incremental_read_obs_mouse 
+END TEST ( 2023-07-02 14:46:50.634455 ):  test_incremental_read_obs_mouse 
+START TEST ( 2023-07-02 14:46:50.636518 ):  test_incremental_read_var_mouse 
+END TEST ( 2023-07-02 14:46:52.02957 ):  test_incremental_read_var_mouse 
+START TEST ( 2023-07-02 14:46:52.031717 ):  test_incremental_read_X_human 
+END TEST ( 2023-07-02 15:06:21.675927 ):  test_incremental_read_X_human 
+START TEST ( 2023-07-02 15:06:21.678379 ):  test_incremental_read_X_human-large-buffer-size 
+END TEST ( 2023-07-02 15:38:51.28431 ):  test_incremental_read_X_human-large-buffer-size 
+START TEST ( 2023-07-02 15:38:51.361892 ):  test_incremental_read_X_mouse 
+END TEST ( 2023-07-02 15:43:56.700087 ):  test_incremental_read_X_mouse 
+START TEST ( 2023-07-02 15:43:56.720547 ):  test_incremental_read_X_mouse-large-buffer-size 
+END TEST ( 2023-07-02 15:45:23.18604 ):  test_incremental_read_X_mouse-large-buffer-size 
+START TEST ( 2023-07-02 15:45:23.188516 ):  test_incremental_query_human_brain 
+END TEST ( 2023-07-02 15:46:27.33182 ):  test_incremental_query_human_brain 
+START TEST ( 2023-07-02 15:46:27.333765 ):  test_incremental_query_human_aorta 
+END TEST ( 2023-07-02 15:46:40.686538 ):  test_incremental_query_human_aorta 
+START TEST ( 2023-07-02 15:46:40.688573 ):  test_incremental_query_mouse_brain 
+END TEST ( 2023-07-02 15:46:51.875727 ):  test_incremental_query_mouse_brain 
+START TEST ( 2023-07-02 15:46:51.877772 ):  test_incremental_query_mouse_aorta 
+END TEST ( 2023-07-02 15:46:58.295933 ):  test_incremental_query_mouse_aorta 
+START TEST ( 2023-07-02 15:46:58.29842 ):  test_seurat_small-query 
+END TEST ( 2023-07-02 15:47:20.06609 ):  test_seurat_small-query 
+START TEST ( 2023-07-02 15:47:20.067965 ):  test_seurat_10K-cells-human 
+END TEST ( 2023-07-02 15:47:32.549183 ):  test_seurat_10K-cells-human 
+START TEST ( 2023-07-02 15:47:32.550956 ):  test_seurat_100K-cells-human 
+END TEST ( 2023-07-02 15:48:22.766206 ):  test_seurat_100K-cells-human 
+START TEST ( 2023-07-02 15:48:22.768067 ):  test_seurat_250K-cells-human 
+END TEST ( 2023-07-02 15:50:07.128338 ):  test_seurat_250K-cells-human 
+START TEST ( 2023-07-02 15:50:07.130188 ):  test_seurat_500K-cells-human 
+END TEST ( 2023-07-02 15:53:52.198963 ):  test_seurat_500K-cells-human 
+START TEST ( 2023-07-02 15:53:52.200954 ):  test_seurat_750K-cells-human 
+END TEST ( 2023-07-02 15:59:06.944844 ):  test_seurat_750K-cells-human 
+START TEST ( 2023-07-02 15:59:06.946713 ):  test_seurat_1M-cells-human 
+END TEST ( 2023-07-02 15:59:50.717664 ):  test_seurat_1M-cells-human 
+START TEST ( 2023-07-02 15:59:50.720414 ):  test_seurat_common-tissue 
+END TEST ( 2023-07-02 16:03:47.743072 ):  test_seurat_common-tissue 
+START TEST ( 2023-07-02 16:03:47.745073 ):  test_seurat_common-tissue-large-buffer-size 
+END TEST ( 2023-07-02 16:07:50.285648 ):  test_seurat_common-tissue-large-buffer-size 
+START TEST ( 2023-07-02 16:07:50.287765 ):  test_seurat_common-cell-type 
+END TEST ( 2023-07-02 16:22:28.235837 ):  test_seurat_common-cell-type 
+START TEST ( 2023-07-02 16:22:28.241764 ):  test_seurat_common-cell-type-large-buffer-size 
+END TEST ( 2023-07-02 17:38:56.592504 ):  test_seurat_common-cell-type-large-buffer-size 
+START TEST ( 2023-07-02 17:38:56.5975 ):  test_seurat_whole-enchilada-large-buffer-size 
+END TEST ( 2023-07-02 17:38:56.60277 ):  test_seurat_whole-enchilada-large-buffer-size 
 ```
 
-- `acceptance-tests-logs-2023-06-23.csv `
+- `acceptance-tests-logs-2023-07-02.csv`
 
 ```
 test,user,system,real,test_result
-test_load_obs_human,15.883,90.46,7.412,expect_true(nrow(obs_df) > 0): expectation_success: nrow(obs_df) > 0 is not TRUE 
-test_load_var_human,0.446000000000002,0.525999999999996,1.681,expect_true(nrow(var_df) > 0): expectation_success: nrow(var_df) > 0 is not TRUE 
-test_load_obs_mouse,2.334,10.173,2.293,expect_true(nrow(obs_df) > 0): expectation_success: nrow(obs_df) > 0 is not TRUE 
-test_load_var_mouse,0.402000000000001,0.498999999999995,1.706,expect_true(nrow(var_df) > 0): expectation_success: nrow(var_df) > 0 is not TRUE 
-test_incremental_read_obs_human,12.644,89.335,5.486,expect_true(table_iter_is_ok(obs_iter)): expectation_success: table_iter_is_ok(obs_iter) is not TRUE 
-test_incremental_read_var_human,0.431000000000004,0.623999999999995,1.544,expect_true(table_iter_is_ok(var_iter)): expectation_success: table_iter_is_ok(var_iter) is not TRUE 
-test_incremental_read_X_human,8541.548,14085.129,1301.948,expect_true(table_iter_is_ok(X_iter)): expectation_success: table_iter_is_ok(X_iter) is not TRUE 
-test_incremental_read_X_human-large-buffer-size,8298.131,55528.271,1632.207,expect_true(table_iter_is_ok(X_iter)): expectation_success: table_iter_is_ok(X_iter) is not TRUE 
-test_incremental_read_obs_mouse,2.98799999999756,11.2309999999998,8.02999999999975,expect_true(table_iter_is_ok(obs_iter)): expectation_success: table_iter_is_ok(obs_iter) is not TRUE 
-test_incremental_read_var_mouse,0.781999999999243,0.567000000010012,2.75600000000031,expect_true(table_iter_is_ok(var_iter)): expectation_success: table_iter_is_ok(var_iter) is not TRUE 
-test_incremental_read_X_mouse,956.803999999996,1747.19899999999,216.037,expect_true(table_iter_is_ok(X_iter)): expectation_success: table_iter_is_ok(X_iter) is not TRUE 
-test_incremental_read_X_mouse-large-buffer-size,944.569000000003,1788.836,89.9070000000002,expect_true(table_iter_is_ok(X_iter)): expectation_success: table_iter_is_ok(X_iter) is not TRUE 
-test_incremental_query_human_brain,229.760000000002,235.297999999995,67.5410000000002,expect_true(table_iter_is_ok(query$obs())): expectation_success: table_iter_is_ok(query$obs()) is not TRUE ; expect_true(table_iter_is_ok(query$var())): expectation_success: table_iter_is_ok(query$var()) is not TRUE ; expect_true(table_iter_is_ok(query$X("raw")$tables())): expectation_success: table_iter_is_ok(query$X("raw")$tables()) is not TRUE 
-test_incremental_query_human_aorta,14.7129999999997,69.6689999999944,13.0839999999998,expect_true(table_iter_is_ok(query$obs())): expectation_success: table_iter_is_ok(query$obs()) is not TRUE ; expect_true(table_iter_is_ok(query$var())): expectation_success: table_iter_is_ok(query$var()) is not TRUE ; expect_true(table_iter_is_ok(query$X("raw")$tables())): expectation_success: table_iter_is_ok(query$X("raw")$tables()) is not TRUE 
-test_incremental_query_mouse_brain,46.494999999999,56.6560000000027,11.3639999999996,expect_true(table_iter_is_ok(query$obs())): expectation_success: table_iter_is_ok(query$obs()) is not TRUE ; expect_true(table_iter_is_ok(query$var())): expectation_success: table_iter_is_ok(query$var()) is not TRUE ; expect_true(table_iter_is_ok(query$X("raw")$tables())): expectation_success: table_iter_is_ok(query$X("raw")$tables()) is not TRUE 
-test_incremental_query_mouse_aorta,14.8260000000009,13.6779999999999,6.78200000000015,expect_true(table_iter_is_ok(query$obs())): expectation_success: table_iter_is_ok(query$obs()) is not TRUE ; expect_true(table_iter_is_ok(query$var())): expectation_success: table_iter_is_ok(query$var()) is not TRUE ; expect_true(table_iter_is_ok(query$X("raw")$tables())): expectation_success: table_iter_is_ok(query$X("raw")$tables()) is not TRUE 
-test_seurat_small-query,24.0690000000031,70.6049999999959,22.018,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
-test_seurat_10K-cells-human,9.0669999999991,9.08899999999267,13.02,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
-test_seurat_100K-cells-human,55.2659999999996,52.5160000000033,51.9010000000003,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
-test_seurat_250K-cells-human,122.486999999997,107.065000000002,109.373,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
-test_seurat_500K-cells-human,246.814000000002,192.854000000007,221.055,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
-test_seurat_750K-cells-human,339.014999999999,291.834999999992,311.924,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
-test_seurat_1M-cells-human,160.785,229.281999999992,51.1480000000001,test_seurat(test_args): Error: Error in `vec_to_Array(x, type)`: long vectors not supported yet: memory.c:3888 
-test_seurat_common-tissue,388.418999999998,256.304000000004,241.336,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
-test_seurat_common-tissue-large-buffer-size,383.98,271.957999999999,246.715,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
-test_seurat_common-cell-type,3408.023,9100.003,1000.399,test_seurat(test_args): Error: Error in `vec_to_Array(x, type)`: long vectors not supported yet: memory.c:3888 
-test_seurat_common-cell-type-large-buffer-size,3552.187,30429.321,4802.434,test_seurat(test_args): Error: Error in `vec_to_Array(x, type)`: long vectors not supported yet: memory.c:3888 
-test_seurat_whole-enchilada-large-buffer-size,0.00400000000081491,0,0.00500000000101863,expect_true(TRUE): expectation_success: TRUE is not TRUE
+test_load_obs_human,16.559,95.552,7.053,expect_true(nrow(obs_df) > 0): expectation_success: nrow(obs_df) > 0 is not TRUE 
+test_load_var_human,0.413,0.480000000000004,1.697,expect_true(nrow(var_df) > 0): expectation_success: nrow(var_df) > 0 is not TRUE 
+test_load_obs_mouse,2.223,7.28399999999999,1.987,expect_true(nrow(obs_df) > 0): expectation_success: nrow(obs_df) > 0 is not TRUE 
+test_load_var_mouse,0.413,0.475000000000009,1.505,expect_true(nrow(var_df) > 0): expectation_success: nrow(var_df) > 0 is not TRUE 
+test_incremental_read_obs_human,18.338,103.328,5.598,expect_true(table_iter_is_ok(obs_iter)): expectation_success: table_iter_is_ok(obs_iter) is not TRUE 
+test_incremental_read_var_human,0.408000000000001,0.482000000000028,1.562,expect_true(table_iter_is_ok(var_iter)): expectation_success: table_iter_is_ok(var_iter) is not TRUE 
+test_incremental_read_obs_mouse,2.351,6.16499999999999,2.415,expect_true(table_iter_is_ok(obs_iter)): expectation_success: table_iter_is_ok(obs_iter) is not TRUE 
+test_incremental_read_var_mouse,0.395000000000003,0.401999999999987,1.392,expect_true(table_iter_is_ok(var_iter)): expectation_success: table_iter_is_ok(var_iter) is not TRUE 
+test_incremental_read_X_human,8479.745,13912.628,1169.643,expect_true(table_iter_is_ok(X_iter)): expectation_success: table_iter_is_ok(X_iter) is not TRUE 
+test_incremental_read_X_human-large-buffer-size,8247.498,77383.086,1949.527,expect_true(table_iter_is_ok(X_iter)): expectation_success: table_iter_is_ok(X_iter) is not TRUE 
+test_incremental_read_X_mouse,960.691000000003,1551.99800000001,305.317,expect_true(table_iter_is_ok(X_iter)): expectation_success: table_iter_is_ok(X_iter) is not TRUE 
+test_incremental_read_X_mouse-large-buffer-size,961.543999999998,1518.712,86.4630000000002,expect_true(table_iter_is_ok(X_iter)): expectation_success: table_iter_is_ok(X_iter) is not TRUE 
+test_incremental_query_human_brain,228.550999999999,269.589999999997,64.1419999999998,expect_true(table_iter_is_ok(query$obs())): expectation_success: table_iter_is_ok(query$obs()) is not TRUE ; expect_true(table_iter_is_ok(query$var())): expectation_success: table_iter_is_ok(query$var()) is not TRUE ; expect_true(table_iter_is_ok(query$X("raw")$tables())): expectation_success: table_iter_is_ok(query$X("raw")$tables()) is not TRUE 
+test_incremental_query_human_aorta,19.0260000000017,72.7629999999917,13.3519999999999,expect_true(table_iter_is_ok(query$obs())): expectation_success: table_iter_is_ok(query$obs()) is not TRUE ; expect_true(table_iter_is_ok(query$var())): expectation_success: table_iter_is_ok(query$var()) is not TRUE ; expect_true(table_iter_is_ok(query$X("raw")$tables())): expectation_success: table_iter_is_ok(query$X("raw")$tables()) is not TRUE 
+test_incremental_query_mouse_brain,46.9169999999976,56.8659999999945,11.1860000000001,expect_true(table_iter_is_ok(query$obs())): expectation_success: table_iter_is_ok(query$obs()) is not TRUE ; expect_true(table_iter_is_ok(query$var())): expectation_success: table_iter_is_ok(query$var()) is not TRUE ; expect_true(table_iter_is_ok(query$X("raw")$tables())): expectation_success: table_iter_is_ok(query$X("raw")$tables()) is not TRUE 
+test_incremental_query_mouse_aorta,12.260000000002,11.2419999999984,6.41700000000037,expect_true(table_iter_is_ok(query$obs())): expectation_success: table_iter_is_ok(query$obs()) is not TRUE ; expect_true(table_iter_is_ok(query$var())): expectation_success: table_iter_is_ok(query$var()) is not TRUE ; expect_true(table_iter_is_ok(query$X("raw")$tables())): expectation_success: table_iter_is_ok(query$X("raw")$tables()) is not TRUE 
+test_seurat_small-query,25.7360000000008,70.429999999993,21.7669999999998,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_10K-cells-human,9.01800000000003,9.08999999999651,12.4810000000002,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_100K-cells-human,54.7450000000026,48.3930000000109,50.2150000000001,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_250K-cells-human,118.756999999998,94.1370000000024,104.36,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_500K-cells-human,253.110000000001,194.872000000003,225.068,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_750K-cells-human,344.812999999998,264.630999999994,314.742999999999,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_1M-cells-human,160.532999999999,234.426000000007,43.7690000000002,test_seurat(test_args): Error: Error in `vec_to_Array(x, type)`: long vectors not supported yet: memory.c:3888 
+test_seurat_common-tissue,387.287,257.248000000007,237.022,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_common-tissue-large-buffer-size,382.359,260.178,242.54,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_common-cell-type,3359.342,11201.16,877.945000000001,test_seurat(test_args): Error: Error in `vec_to_Array(x, type)`: long vectors not supported yet: memory.c:3888 
+test_seurat_common-cell-type-large-buffer-size,3579.832,33378.649,4588.348,test_seurat(test_args): Error: Error in `vec_to_Array(x, type)`: long vectors not supported yet: memory.c:3888 
+test_seurat_whole-enchilada-large-buffer-size,0.00400000000081491,0,0.00400000000081491,expect_true(TRUE): expectation_success: TRUE is not TRUE 
 ```
 
 

--- a/api/r/cellxgene.census/tests/README.md
+++ b/api/r/cellxgene.census/tests/README.md
@@ -42,6 +42,179 @@ When run, please record the results in this file (below) and commit the change t
   - `stdout.txt`
   - `acceptance-tests-logs-[YYY]-[MM]-[DD].csv`
 
+
+## 2023-06-29
+
+- Host: EC2 instance type: `r6id.x32xlarge`, all nvme mounted as swap.
+- Uname: Linux ip-172-31-62-52 5.19.0-1027-aws #28~22.04.1-Ubuntu SMP Wed May 31 18:30:36 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
+- Census version
+
+```
+> cellxgene.census::get_census_version_description('latest')
+$release_date
+[1] ""
+
+$release_build
+[1] "2023-06-28"
+
+$soma.uri
+[1] "s3://cellxgene-data-public/cell-census/2023-06-28/soma/"
+
+$soma.s3_region
+[1] "us-west-2"
+
+$h5ads.uri
+[1] "s3://cellxgene-data-public/cell-census/2023-06-28/h5ads/"
+
+$h5ads.s3_region
+[1] "us-west-2"
+
+$alias
+[1] "latest"
+
+$census_version
+[1] "latest"
+```
+
+- R session info 
+
+```
+> library("cellxgene.census"); sessionInfo()
+R version 4.3.0 (2023-04-21)
+Platform: x86_64-pc-linux-gnu (64-bit)
+Running under: Ubuntu 22.04.2 LTS
+
+Matrix products: default
+BLAS:   /usr/lib/x86_64-linux-gnu/blas/libblas.so.3.10.0 
+LAPACK: /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.10.0
+
+locale:
+ [1] LC_CTYPE=C.UTF-8       LC_NUMERIC=C           LC_TIME=C.UTF-8       
+ [4] LC_COLLATE=C.UTF-8     LC_MONETARY=C.UTF-8    LC_MESSAGES=C.UTF-8   
+ [7] LC_PAPER=C.UTF-8       LC_NAME=C              LC_ADDRESS=C          
+[10] LC_TELEPHONE=C         LC_MEASUREMENT=C.UTF-8 LC_IDENTIFICATION=C   
+
+time zone: America/Los_Angeles
+tzcode source: system (glibc)
+
+attached base packages:
+[1] stats     graphics  grDevices utils     datasets  methods   base     
+
+other attached packages:
+[1] cellxgene.census_0.0.0.9000
+
+loaded via a namespace (and not attached):
+ [1] vctrs_0.6.3           httr_1.4.6            cli_3.6.1            
+ [4] tiledbsoma_0.0.0.9030 rlang_1.1.1           purrr_1.0.1          
+ [7] assertthat_0.2.1      data.table_1.14.8     jsonlite_1.8.5       
+[10] glue_1.6.2            bit_4.0.5             triebeard_0.4.1      
+[13] grid_4.3.0            RcppSpdlog_0.0.13     base64enc_0.1-3      
+[16] lifecycle_1.0.3       compiler_4.3.0        fs_1.6.2             
+[19] Rcpp_1.0.10           aws.s3_0.3.21         lattice_0.21-8       
+[22] digest_0.6.31         R6_2.5.1              tidyselect_1.2.0     
+[25] curl_5.0.1            magrittr_2.0.3        urltools_1.7.3       
+[28] Matrix_1.5-4.1        tools_4.3.0           bit64_4.0.5          
+[31] aws.signature_0.6.0   spdl_0.0.5            arrow_12.0.1         
+[34] xml2_1.3.4   
+
+```
+
+- `stdout.txt`
+
+```
+START TEST ( 2023-06-28 13:07:31.895118 ):  test_load_obs_human 
+END TEST ( 2023-06-28 13:07:39.308527 ):  test_load_obs_human 
+START TEST ( 2023-06-28 13:07:39.310306 ):  test_load_var_human 
+END TEST ( 2023-06-28 13:07:40.99671 ):  test_load_var_human 
+START TEST ( 2023-06-28 13:07:40.998601 ):  test_load_obs_mouse 
+END TEST ( 2023-06-28 13:07:43.292537 ):  test_load_obs_mouse 
+START TEST ( 2023-06-28 13:07:43.294842 ):  test_load_var_mouse 
+END TEST ( 2023-06-28 13:07:45.002476 ):  test_load_var_mouse 
+START TEST ( 2023-06-28 13:07:45.004729 ):  test_incremental_read_obs_human 
+END TEST ( 2023-06-28 13:07:50.491426 ):  test_incremental_read_obs_human 
+START TEST ( 2023-06-28 13:07:50.493703 ):  test_incremental_read_var_human 
+END TEST ( 2023-06-28 13:07:52.038702 ):  test_incremental_read_var_human 
+START TEST ( 2023-06-28 13:07:52.041194 ):  test_incremental_read_X_human 
+END TEST ( 2023-06-28 13:29:33.990447 ):  test_incremental_read_X_human 
+START TEST ( 2023-06-28 13:29:33.993099 ):  test_incremental_read_X_human-large-buffer-size 
+END TEST ( 2023-06-28 13:56:46.292904 ):  test_incremental_read_X_human-large-buffer-size 
+START TEST ( 2023-06-28 13:56:46.410884 ):  test_incremental_read_obs_mouse 
+END TEST ( 2023-06-28 13:56:54.468978 ):  test_incremental_read_obs_mouse 
+START TEST ( 2023-06-28 13:56:54.496171 ):  test_incremental_read_var_mouse 
+END TEST ( 2023-06-28 13:56:57.260737 ):  test_incremental_read_var_mouse 
+START TEST ( 2023-06-28 13:56:57.299614 ):  test_incremental_read_X_mouse 
+END TEST ( 2023-06-28 14:00:33.340603 ):  test_incremental_read_X_mouse 
+START TEST ( 2023-06-28 14:00:33.342839 ):  test_incremental_read_X_mouse-large-buffer-size 
+END TEST ( 2023-06-28 14:02:03.251537 ):  test_incremental_read_X_mouse-large-buffer-size 
+START TEST ( 2023-06-28 14:02:03.253954 ):  test_incremental_query_human_brain 
+END TEST ( 2023-06-28 14:03:10.796619 ):  test_incremental_query_human_brain 
+START TEST ( 2023-06-28 14:03:10.79851 ):  test_incremental_query_human_aorta 
+END TEST ( 2023-06-28 14:03:23.883367 ):  test_incremental_query_human_aorta 
+START TEST ( 2023-06-28 14:03:23.885332 ):  test_incremental_query_mouse_brain 
+END TEST ( 2023-06-28 14:03:35.250481 ):  test_incremental_query_mouse_brain 
+START TEST ( 2023-06-28 14:03:35.252468 ):  test_incremental_query_mouse_aorta 
+END TEST ( 2023-06-28 14:03:42.035149 ):  test_incremental_query_mouse_aorta 
+START TEST ( 2023-06-28 14:03:42.037484 ):  test_seurat_small-query 
+END TEST ( 2023-06-28 14:04:04.055966 ):  test_seurat_small-query 
+START TEST ( 2023-06-28 14:04:04.057835 ):  test_seurat_10K-cells-human 
+END TEST ( 2023-06-28 14:04:17.078379 ):  test_seurat_10K-cells-human 
+START TEST ( 2023-06-28 14:04:17.080181 ):  test_seurat_100K-cells-human 
+END TEST ( 2023-06-28 14:05:08.98193 ):  test_seurat_100K-cells-human 
+START TEST ( 2023-06-28 14:05:08.983845 ):  test_seurat_250K-cells-human 
+END TEST ( 2023-06-28 14:06:58.356763 ):  test_seurat_250K-cells-human 
+START TEST ( 2023-06-28 14:06:58.358616 ):  test_seurat_500K-cells-human 
+END TEST ( 2023-06-28 14:10:39.413578 ):  test_seurat_500K-cells-human 
+START TEST ( 2023-06-28 14:10:39.415487 ):  test_seurat_750K-cells-human 
+END TEST ( 2023-06-28 14:15:51.340092 ):  test_seurat_750K-cells-human 
+START TEST ( 2023-06-28 14:15:51.341954 ):  test_seurat_1M-cells-human 
+END TEST ( 2023-06-28 14:16:42.491952 ):  test_seurat_1M-cells-human 
+START TEST ( 2023-06-28 14:16:42.494254 ):  test_seurat_common-tissue 
+END TEST ( 2023-06-28 14:20:43.831188 ):  test_seurat_common-tissue 
+START TEST ( 2023-06-28 14:20:43.833142 ):  test_seurat_common-tissue-large-buffer-size 
+END TEST ( 2023-06-28 14:24:50.548616 ):  test_seurat_common-tissue-large-buffer-size 
+START TEST ( 2023-06-28 14:24:50.550572 ):  test_seurat_common-cell-type 
+END TEST ( 2023-06-28 14:41:30.949797 ):  test_seurat_common-cell-type 
+START TEST ( 2023-06-28 14:41:30.952931 ):  test_seurat_common-cell-type-large-buffer-size 
+END TEST ( 2023-06-28 16:01:33.389666 ):  test_seurat_common-cell-type-large-buffer-size 
+START TEST ( 2023-06-28 16:01:33.393631 ):  test_seurat_whole-enchilada-large-buffer-size 
+END TEST ( 2023-06-28 16:01:33.398993 ):  test_seurat_whole-enchilada-large-buffer-size
+```
+
+- `acceptance-tests-logs-2023-06-23.csv `
+
+```
+test,user,system,real,test_result
+test_load_obs_human,15.883,90.46,7.412,expect_true(nrow(obs_df) > 0): expectation_success: nrow(obs_df) > 0 is not TRUE 
+test_load_var_human,0.446000000000002,0.525999999999996,1.681,expect_true(nrow(var_df) > 0): expectation_success: nrow(var_df) > 0 is not TRUE 
+test_load_obs_mouse,2.334,10.173,2.293,expect_true(nrow(obs_df) > 0): expectation_success: nrow(obs_df) > 0 is not TRUE 
+test_load_var_mouse,0.402000000000001,0.498999999999995,1.706,expect_true(nrow(var_df) > 0): expectation_success: nrow(var_df) > 0 is not TRUE 
+test_incremental_read_obs_human,12.644,89.335,5.486,expect_true(table_iter_is_ok(obs_iter)): expectation_success: table_iter_is_ok(obs_iter) is not TRUE 
+test_incremental_read_var_human,0.431000000000004,0.623999999999995,1.544,expect_true(table_iter_is_ok(var_iter)): expectation_success: table_iter_is_ok(var_iter) is not TRUE 
+test_incremental_read_X_human,8541.548,14085.129,1301.948,expect_true(table_iter_is_ok(X_iter)): expectation_success: table_iter_is_ok(X_iter) is not TRUE 
+test_incremental_read_X_human-large-buffer-size,8298.131,55528.271,1632.207,expect_true(table_iter_is_ok(X_iter)): expectation_success: table_iter_is_ok(X_iter) is not TRUE 
+test_incremental_read_obs_mouse,2.98799999999756,11.2309999999998,8.02999999999975,expect_true(table_iter_is_ok(obs_iter)): expectation_success: table_iter_is_ok(obs_iter) is not TRUE 
+test_incremental_read_var_mouse,0.781999999999243,0.567000000010012,2.75600000000031,expect_true(table_iter_is_ok(var_iter)): expectation_success: table_iter_is_ok(var_iter) is not TRUE 
+test_incremental_read_X_mouse,956.803999999996,1747.19899999999,216.037,expect_true(table_iter_is_ok(X_iter)): expectation_success: table_iter_is_ok(X_iter) is not TRUE 
+test_incremental_read_X_mouse-large-buffer-size,944.569000000003,1788.836,89.9070000000002,expect_true(table_iter_is_ok(X_iter)): expectation_success: table_iter_is_ok(X_iter) is not TRUE 
+test_incremental_query_human_brain,229.760000000002,235.297999999995,67.5410000000002,expect_true(table_iter_is_ok(query$obs())): expectation_success: table_iter_is_ok(query$obs()) is not TRUE ; expect_true(table_iter_is_ok(query$var())): expectation_success: table_iter_is_ok(query$var()) is not TRUE ; expect_true(table_iter_is_ok(query$X("raw")$tables())): expectation_success: table_iter_is_ok(query$X("raw")$tables()) is not TRUE 
+test_incremental_query_human_aorta,14.7129999999997,69.6689999999944,13.0839999999998,expect_true(table_iter_is_ok(query$obs())): expectation_success: table_iter_is_ok(query$obs()) is not TRUE ; expect_true(table_iter_is_ok(query$var())): expectation_success: table_iter_is_ok(query$var()) is not TRUE ; expect_true(table_iter_is_ok(query$X("raw")$tables())): expectation_success: table_iter_is_ok(query$X("raw")$tables()) is not TRUE 
+test_incremental_query_mouse_brain,46.494999999999,56.6560000000027,11.3639999999996,expect_true(table_iter_is_ok(query$obs())): expectation_success: table_iter_is_ok(query$obs()) is not TRUE ; expect_true(table_iter_is_ok(query$var())): expectation_success: table_iter_is_ok(query$var()) is not TRUE ; expect_true(table_iter_is_ok(query$X("raw")$tables())): expectation_success: table_iter_is_ok(query$X("raw")$tables()) is not TRUE 
+test_incremental_query_mouse_aorta,14.8260000000009,13.6779999999999,6.78200000000015,expect_true(table_iter_is_ok(query$obs())): expectation_success: table_iter_is_ok(query$obs()) is not TRUE ; expect_true(table_iter_is_ok(query$var())): expectation_success: table_iter_is_ok(query$var()) is not TRUE ; expect_true(table_iter_is_ok(query$X("raw")$tables())): expectation_success: table_iter_is_ok(query$X("raw")$tables()) is not TRUE 
+test_seurat_small-query,24.0690000000031,70.6049999999959,22.018,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_10K-cells-human,9.0669999999991,9.08899999999267,13.02,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_100K-cells-human,55.2659999999996,52.5160000000033,51.9010000000003,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_250K-cells-human,122.486999999997,107.065000000002,109.373,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_500K-cells-human,246.814000000002,192.854000000007,221.055,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_750K-cells-human,339.014999999999,291.834999999992,311.924,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_1M-cells-human,160.785,229.281999999992,51.1480000000001,test_seurat(test_args): Error: Error in `vec_to_Array(x, type)`: long vectors not supported yet: memory.c:3888 
+test_seurat_common-tissue,388.418999999998,256.304000000004,241.336,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_common-tissue-large-buffer-size,383.98,271.957999999999,246.715,test_seurat(test_args): expectation_success: is(this_seurat, "Seurat") is not TRUE ; test_seurat(test_args): expectation_success: ncol(this_seurat) > 0 is not TRUE 
+test_seurat_common-cell-type,3408.023,9100.003,1000.399,test_seurat(test_args): Error: Error in `vec_to_Array(x, type)`: long vectors not supported yet: memory.c:3888 
+test_seurat_common-cell-type-large-buffer-size,3552.187,30429.321,4802.434,test_seurat(test_args): Error: Error in `vec_to_Array(x, type)`: long vectors not supported yet: memory.c:3888 
+test_seurat_whole-enchilada-large-buffer-size,0.00400000000081491,0,0.00500000000101863,expect_true(TRUE): expectation_success: TRUE is not TRUE
+```
+
+
 ## 2023-06-23
 
 - Host: EC2 instance type: `r6id.x32xlarge`, all nvme mounted as swap.

--- a/api/r/cellxgene.census/tests/testthat/ListReporterToFile.R
+++ b/api/r/cellxgene.census/tests/testthat/ListReporterToFile.R
@@ -6,11 +6,10 @@ ListReporterToFile <- R6::R6Class("ListReporterToFile",
   public = list(
     
     initialize = function(to_file="acceptance-tests-logs.csv") {
-      header <- c("test","user","system","real", "test_result_message")
       private$to_file <- to_file
       
       file_handle <- file(private$to_file)
-      base::writeLines("test,user,system,real", con=file_handle)
+      base::writeLines("test,user,system,real,test_result", con=file_handle)
       close(file_handle)
       
       super$initialize()

--- a/api/r/cellxgene.census/tests/testthat/ListReporterToFile.R
+++ b/api/r/cellxgene.census/tests/testthat/ListReporterToFile.R
@@ -4,57 +4,54 @@
 ListReporterToFile <- R6::R6Class("ListReporterToFile",
   inherit = ListReporter,
   public = list(
-    
-    initialize = function(to_file="acceptance-tests-logs.csv") {
+    initialize = function(to_file = "acceptance-tests-logs.csv") {
       private$to_file <- to_file
-      
+
       file_handle <- file(private$to_file)
-      base::writeLines("test,user,system,real,test_result", con=file_handle)
+      base::writeLines("test,user,system,real,test_result", con = file_handle)
       close(file_handle)
-      
+
       super$initialize()
     },
-    
     start_test = function(context, test) {
       # print stdout for live progress
       cat("START TEST (", as.character(Sys.time()), "): ", test, "\n")
       super$start_test()
     },
-    
     end_test = function(context, test) {
       super$end_test(context, test)
       this_result <- super$get_results()
-      
+
       # get last result
       this_result <- this_result[[length(this_result)]]
-      
+
       # write to file
       file_handle <- file(private$to_file, "a")
-      base::writeLines(con = file_handle,
-                 text = paste(this_result$test, 
-                              this_result$user, 
-                              this_result$system, 
-                              this_result$real,
-                              private$convert_test_output_to_string(this_result$results),
-                              sep =","))
+      base::writeLines(
+        con = file_handle,
+        text = paste(this_result$test,
+          this_result$user,
+          this_result$system,
+          this_result$real,
+          private$convert_test_output_to_string(this_result$results),
+          sep = ","
+        )
+      )
       close(file_handle)
-      
+
       # print stdout for live progress
       cat("END TEST (", as.character(Sys.time()), "): ", test, "\n")
     }
   ),
-                                  
   private = list(
     to_file = NULL,
-    
     convert_test_output_to_string = function(results) {
-      results_list <- lapply(results, function(x){
+      results_list <- lapply(results, function(x) {
         call_title <- x$srcref
         call_result <- gsub("\n+", " ", as.character(x))
         paste0(call_title, ": ", call_result)
       })
-      return(paste0(as.vector(results_list), collapse="; "))
+      return(paste0(as.vector(results_list), collapse = "; "))
     }
-    
   )
 )

--- a/api/r/cellxgene.census/tests/testthat/ListReporterToFile.R
+++ b/api/r/cellxgene.census/tests/testthat/ListReporterToFile.R
@@ -16,6 +16,12 @@ ListReporterToFile <- R6::R6Class("ListReporterToFile",
       super$initialize()
     },
     
+    start_test = function(context, test) {
+      # print stdout for live progress
+      cat("START TEST (", as.character(Sys.time()), "): ", test, "\n")
+      super$start_test()
+    },
+    
     end_test = function(context, test) {
       super$end_test(context, test)
       this_result <- super$get_results()
@@ -32,6 +38,9 @@ ListReporterToFile <- R6::R6Class("ListReporterToFile",
                               this_result$real, 
                               sep =","))
       close(file_handle)
+      
+      # print stdout for live progress
+      cat("END TEST (", as.character(Sys.time()), "): ", test, "\n")
     }
   ),
                                   

--- a/api/r/cellxgene.census/tests/testthat/ListReporterToFile.R
+++ b/api/r/cellxgene.census/tests/testthat/ListReporterToFile.R
@@ -35,7 +35,8 @@ ListReporterToFile <- R6::R6Class("ListReporterToFile",
                  text = paste(this_result$test, 
                               this_result$user, 
                               this_result$system, 
-                              this_result$real, 
+                              this_result$real,
+                              private$convert_test_output_to_string(this_result$results),
                               sep =","))
       close(file_handle)
       
@@ -45,6 +46,16 @@ ListReporterToFile <- R6::R6Class("ListReporterToFile",
   ),
                                   
   private = list(
-    to_file=NULL
+    to_file = NULL,
+    
+    convert_test_output_to_string = function(results) {
+      results_list <- lapply(results, function(x){
+        call_title <- x$srcref
+        call_result <- gsub("\n+", " ", as.character(x))
+        paste0(call_title, ": ", call_result)
+      })
+      return(paste0(as.vector(results_list), collapse="; "))
+    }
+    
   )
 )

--- a/api/r/cellxgene.census/tests/testthat/ListReporterToFile.R
+++ b/api/r/cellxgene.census/tests/testthat/ListReporterToFile.R
@@ -1,0 +1,41 @@
+# Children class of testthat::ListReporter
+# writes test results to a file as it runs them
+
+ListReporterToFile <- R6::R6Class("ListReporterToFile",
+  inherit = ListReporter,
+  public = list(
+    
+    initialize = function(to_file="acceptance-tests-logs.csv") {
+      header <- c("test","user","system","real")
+      private$to_file <- to_file
+      
+      file_handle <- file(private$to_file)
+      base::writeLines("test,user,system,real", con=file_handle)
+      close(file_handle)
+      
+      super$initialize()
+    },
+    
+    end_test = function(context, test) {
+      super$end_test(context, test)
+      this_result <- super$get_results()
+      
+      # get last result
+      this_result <- this_result[[length(this_result)]]
+      
+      # write to file
+      file_handle <- file(private$to_file, "a")
+      base::writeLines(con = file_handle,
+                 text = paste(this_result$test, 
+                              this_result$user, 
+                              this_result$system, 
+                              this_result$real, 
+                              sep =","))
+      close(file_handle)
+    }
+  ),
+                                  
+  private = list(
+    to_file=NULL
+  )
+)

--- a/api/r/cellxgene.census/tests/testthat/ListReporterToFile.R
+++ b/api/r/cellxgene.census/tests/testthat/ListReporterToFile.R
@@ -6,7 +6,7 @@ ListReporterToFile <- R6::R6Class("ListReporterToFile",
   public = list(
     
     initialize = function(to_file="acceptance-tests-logs.csv") {
-      header <- c("test","user","system","real")
+      header <- c("test","user","system","real", "test_result_message")
       private$to_file <- to_file
       
       file_handle <- file(private$to_file)

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests-run-script.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests-run-script.R
@@ -1,0 +1,7 @@
+# Run as Rscript acceptance-tests-run-script.R
+library("cellxgene.census")
+library("testthat")
+source("./ListReporterToFile.R")
+
+reporter <- ListReporterToFile$new(paste0("acceptance-tests-logs-", Sys.Date(), ".csv"))
+test_file("acceptance-tests.R", reporter = reporter)

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -147,7 +147,7 @@ test_that("test_incremental_query_human_brain", {
   query <- tiledbsoma::SOMAExperimentAxisQuery$new(
     experiment = census$get("census_data")$get(organism),
     measurement_name = "RNA", 
-    obs_query = SOMAAxisQuery$new(value_filter = obs_value_filter)
+    obs_query = tiledbsoma::SOMAAxisQuery$new(value_filter = obs_value_filter)
   )
   
   expect_true(table_iter_is_ok(query$obs()))
@@ -166,7 +166,7 @@ test_that("test_incremental_query_human_aorta", {
   query <- tiledbsoma::SOMAExperimentAxisQuery$new(
     experiment = census$get("census_data")$get(organism),
     measurement_name = "RNA", 
-    obs_query = SOMAAxisQuery$new(value_filter = obs_value_filter)
+    obs_query = tiledbsoma::SOMAAxisQuery$new(value_filter = obs_value_filter)
   )
   
   expect_true(table_iter_is_ok(query$obs()))
@@ -185,7 +185,7 @@ test_that("test_incremental_query_mouse_brain", {
   query <- tiledbsoma::SOMAExperimentAxisQuery$new(
     experiment = census$get("census_data")$get(organism),
     measurement_name = "RNA", 
-    obs_query = SOMAAxisQuery$new(value_filter = obs_value_filter)
+    obs_query = tiledbsoma::SOMAAxisQuery$new(value_filter = obs_value_filter)
   )
   
   expect_true(table_iter_is_ok(query$obs()))
@@ -204,7 +204,7 @@ test_that("test_incremental_query_mouse_aorta", {
   query <- tiledbsoma::SOMAExperimentAxisQuery$new(
     experiment = census$get("census_data")$get(organism),
     measurement_name = "RNA", 
-    obs_query = SOMAAxisQuery$new(value_filter = obs_value_filter)
+    obs_query = tiledbsoma::SOMAAxisQuery$new(value_filter = obs_value_filter)
   )
   
   expect_true(table_iter_is_ok(query$obs()))

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -150,9 +150,9 @@ test_that("test_incremental_query_human_brain", {
     obs_query = SOMAAxisQuery$new(value_filter = obs_value_filter)
   )
   
-  expect_true(table_iter_is_ok(query$obs())
-  expect_true(table_iter_is_ok(query$var())
-  expect_true(table_iter_is_ok(query$X("raw")$tables())
+  expect_true(table_iter_is_ok(query$obs()))
+  expect_true(table_iter_is_ok(query$var()))
+  expect_true(table_iter_is_ok(query$X("raw")$tables()))
   
 })
 
@@ -169,9 +169,9 @@ test_that("test_incremental_query_human_aorta", {
     obs_query = SOMAAxisQuery$new(value_filter = obs_value_filter)
   )
   
-  expect_true(table_iter_is_ok(query$obs())
-  expect_true(table_iter_is_ok(query$var())
-  expect_true(table_iter_is_ok(query$X("raw")$tables())
+  expect_true(table_iter_is_ok(query$obs()))
+  expect_true(table_iter_is_ok(query$var()))
+  expect_true(table_iter_is_ok(query$X("raw")$tables()))
   
 })
 
@@ -188,9 +188,9 @@ test_that("test_incremental_query_mouse_brain", {
     obs_query = SOMAAxisQuery$new(value_filter = obs_value_filter)
   )
   
-  expect_true(table_iter_is_ok(query$obs())
-  expect_true(table_iter_is_ok(query$var())
-  expect_true(table_iter_is_ok(query$X("raw")$tables())
+  expect_true(table_iter_is_ok(query$obs()))
+  expect_true(table_iter_is_ok(query$var()))
+  expect_true(table_iter_is_ok(query$X("raw")$tables()))
   
 })
 
@@ -207,9 +207,9 @@ test_that("test_incremental_query_mouse_aorta", {
     obs_query = SOMAAxisQuery$new(value_filter = obs_value_filter)
   )
   
-  expect_true(table_iter_is_ok(query$obs())
-  expect_true(table_iter_is_ok(query$var())
-  expect_true(table_iter_is_ok(query$X("raw")$tables())
+  expect_true(table_iter_is_ok(query$obs()))
+  expect_true(table_iter_is_ok(query$var()))
+  expect_true(table_iter_is_ok(query$X("raw")$tables()))
   
 })
 

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -1,39 +1,35 @@
-# These are expensive tests and should be run as part of the automated 
+# These are expensive tests and should be run as part of the automated
 # testing framework. They are meant to be run manually via testthat::test_file()
 
 test_that("test_load_obs_human", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   organism <- "homo_sapiens"
-  
+
   # use subset of columns for speed
-  obs_df = census$get("census_data")$get(organism)$obs$read(column_names = c("soma_joinid", "cell_type", "tissue"))
-  obs_df = as.data.frame(obs_df$concat())
+  obs_df <- census$get("census_data")$get(organism)$obs$read(column_names = c("soma_joinid", "cell_type", "tissue"))
+  obs_df <- as.data.frame(obs_df$concat())
   expect_true(nrow(obs_df) > 0)
 })
 
 test_that("test_load_var_human", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   organism <- "homo_sapiens"
-  
+
   var_df <- census$get("census_data")$get(organism)$ms$get("RNA")$var$read()
   var_df <- as.data.frame(var_df$concat())
   expect_true(nrow(var_df) > 0)
-  
 })
 
 test_that("test_load_obs_mouse", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   organism <- "mus_musculus"
-  
+
   # use subset of columns for speed
   obs_df <- census$get("census_data")$get(organism)$obs$read(column_names = c("soma_joinid", "cell_type", "tissue"))
   obs_df <- as.data.frame(obs_df$concat())
@@ -41,118 +37,104 @@ test_that("test_load_obs_mouse", {
 })
 
 test_that("test_load_var_mouse", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   organism <- "mus_musculus"
-  
+
   var_df <- census$get("census_data")$get(organism)$ms$get("RNA")$var$read()
   var_df <- as.data.frame(var_df$concat())
   expect_true(nrow(var_df) > 0)
-  
 })
 
 test_that("test_incremental_read_obs_human", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   organism <- "homo_sapiens"
-  
+
   # use subset of columns for speed
   obs_iter <- census$get("census_data")$get(organism)$obs$read(column_names = c("soma_joinid", "cell_type", "tissue"))
   expect_true(table_iter_is_ok(obs_iter))
 })
 
 test_that("test_incremental_read_var_human", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   organism <- "homo_sapiens"
-  
+
   var_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$var$read()
   expect_true(table_iter_is_ok(var_iter))
 })
 
 test_that("test_incremental_read_X_human", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   organism <- "homo_sapiens"
-  
-  # Warning that results cannot be concat because it 
+
+  # Warning that results cannot be concat because it
   # exceeds R's capability to allocate vectors beyond 32bit
   expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables())
   expect_true(table_iter_is_ok(X_iter))
-  
 })
 
 test_that("test_incremental_read_X_human-large-buffer-size", {
-              
   census <- open_soma_latest_for_test(soma.init_buffer_bytes = paste(4 * 1024**3))
   on.exit(census$close(), add = TRUE)
-  
+
   organism <- "homo_sapiens"
-  
-  # Warning that results cannot be concat because it 
+
+  # Warning that results cannot be concat because it
   # exceeds R's capability to allocate vectors beyond 32bit
   expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables())
   expect_true(table_iter_is_ok(X_iter))
-  
 })
 
 test_that("test_incremental_read_obs_mouse", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   organism <- "mus_musculus"
-  
+
   # use subset of columns for speed
   obs_iter <- census$get("census_data")$get(organism)$obs$read(column_names = c("soma_joinid", "cell_type", "tissue"))
   expect_true(table_iter_is_ok(obs_iter))
 })
 
 test_that("test_incremental_read_var_mouse", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   organism <- "mus_musculus"
-  
+
   var_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$var$read()
   expect_true(table_iter_is_ok(var_iter))
 })
 
 test_that("test_incremental_read_X_mouse", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   organism <- "mus_musculus"
-  
-  # Warning that results cannot be concat because it 
+
+  # Warning that results cannot be concat because it
   # exceeds R's capability to allocate vectors beyond 32bit
   expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables())
   expect_true(table_iter_is_ok(X_iter))
-  
 })
 
 test_that("test_incremental_read_X_mouse-large-buffer-size", {
-              
   census <- open_soma_latest_for_test(soma.init_buffer_bytes = paste(4 * 1024**3))
   on.exit(census$close(), add = TRUE)
-  
+
   organism <- "mus_musculus"
-  
-  # Warning that results cannot be concat because it 
+
+  # Warning that results cannot be concat because it
   # exceeds R's capability to allocate vectors beyond 32bit
   expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables())
   expect_true(table_iter_is_ok(X_iter))
-  
 })
 
 test_that("test_incremental_query", {
@@ -162,10 +144,9 @@ test_that("test_incremental_query", {
 })
 
 test_that("test_seurat_small-query", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   test_args <- list(
     census = census,
     organism = "Homo sapiens",
@@ -173,16 +154,14 @@ test_that("test_seurat_small-query", {
     X_name = "raw",
     obs_value_filter = "tissue == 'aorta'"
   )
-  
+
   test_seurat(test_args)
-  
 })
 
 test_that("test_seurat_10K-cells-human", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   test_args <- list(
     census = census,
     organism = "Homo sapiens",
@@ -190,16 +169,14 @@ test_that("test_seurat_10K-cells-human", {
     X_name = "raw",
     obs_coords = 1:10000
   )
-  
+
   test_seurat(test_args)
-                  
 })
 
 test_that("test_seurat_100K-cells-human", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   test_args <- list(
     census = census,
     organism = "Homo sapiens",
@@ -207,16 +184,14 @@ test_that("test_seurat_100K-cells-human", {
     X_name = "raw",
     obs_coords = 1:100000
   )
-  
+
   test_seurat(test_args)
-                  
 })
 
 test_that("test_seurat_250K-cells-human", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   test_args <- list(
     census = census,
     organism = "Homo sapiens",
@@ -224,16 +199,14 @@ test_that("test_seurat_250K-cells-human", {
     X_name = "raw",
     obs_coords = 1:250000
   )
-  
+
   test_seurat(test_args)
-                  
 })
 
 test_that("test_seurat_500K-cells-human", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   test_args <- list(
     census = census,
     organism = "Homo sapiens",
@@ -241,16 +214,14 @@ test_that("test_seurat_500K-cells-human", {
     X_name = "raw",
     obs_coords = 1:500000
   )
-  
+
   test_seurat(test_args)
-                  
 })
 
 test_that("test_seurat_750K-cells-human", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   test_args <- list(
     census = census,
     organism = "Homo sapiens",
@@ -258,16 +229,14 @@ test_that("test_seurat_750K-cells-human", {
     X_name = "raw",
     obs_coords = 1:750000
   )
-  
+
   test_seurat(test_args)
-                  
 })
 
 test_that("test_seurat_1M-cells-human", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   test_args <- list(
     census = census,
     organism = "Homo sapiens",
@@ -275,16 +244,14 @@ test_that("test_seurat_1M-cells-human", {
     X_name = "raw",
     obs_coords = 1:1e6
   )
-  
+
   test_seurat(test_args)
-                  
 })
 
 test_that("test_seurat_common-tissue", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   test_args <- list(
     census = census,
     organism = "Homo sapiens",
@@ -292,16 +259,14 @@ test_that("test_seurat_common-tissue", {
     X_name = "raw",
     obs_value_filter = "tissue == 'brain'"
   )
-  
+
   test_seurat(test_args)
-                  
 })
 
 test_that("test_seurat_common-tissue-large-buffer-size", {
-              
   census <- open_soma_latest_for_test(soma.init_buffer_bytes = paste(4 * 1024**3))
   on.exit(census$close(), add = TRUE)
-  
+
   test_args <- list(
     census = census,
     organism = "Homo sapiens",
@@ -309,16 +274,14 @@ test_that("test_seurat_common-tissue-large-buffer-size", {
     X_name = "raw",
     obs_value_filter = "tissue == 'brain'"
   )
-  
+
   test_seurat(test_args)
-                  
 })
 
 test_that("test_seurat_common-cell-type", {
-              
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   test_args <- list(
     census = census,
     organism = "Homo sapiens",
@@ -326,16 +289,14 @@ test_that("test_seurat_common-cell-type", {
     X_name = "raw",
     obs_value_filter = "cell_type == 'neuron'"
   )
-  
+
   test_seurat(test_args)
-                  
 })
 
 test_that("test_seurat_common-cell-type-large-buffer-size", {
-              
   census <- open_soma_latest_for_test(soma.init_buffer_bytes = paste(4 * 1024**3))
   on.exit(census$close(), add = TRUE)
-  
+
   test_args <- list(
     census = census,
     organism = "Homo sapiens",
@@ -343,27 +304,25 @@ test_that("test_seurat_common-cell-type-large-buffer-size", {
     X_name = "raw",
     obs_value_filter = "cell_type == 'neuron'"
   )
-  
+
   test_seurat(test_args)
-                  
 })
 
 test_that("test_seurat_whole-enchilada-large-buffer-size", {
-  
   # SKIP: R is not capable to load into memory
-  if(FALSE) {
+  if (FALSE) {
     census <- open_soma_latest_for_test(soma.init_buffer_bytes = paste(4 * 1024**3))
     on.exit(census$close(), add = TRUE)
-    
+
     test_args <- list(
       census = census,
       organism = "Homo sapiens",
       measurement_name = "RNA",
       X_name = "raw"
     )
-    
+
     test_seurat(test_args)
   }
-  
+
   expect_true(TRUE)
 })

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -160,7 +160,7 @@ test_that("test_seurat_10K-cells-human", {
     organism = "Homo sapiens",
     measurement_name = "RNA",
     X_name = "raw",
-    obs_coords = 1:10000,
+    obs_coords = 1:10000
   )
   
   test_seurat(test_args)
@@ -177,7 +177,7 @@ test_that("test_seurat_100K-cells-human", {
     organism = "Homo sapiens",
     measurement_name = "RNA",
     X_name = "raw",
-    obs_coords = 1:100000,
+    obs_coords = 1:100000
   )
   
   test_seurat(test_args)
@@ -194,7 +194,7 @@ test_that("test_seurat_common-cell-type", {
     organism = "Homo sapiens",
     measurement_name = "RNA",
     X_name = "raw",
-    obs_value_filter = "cell_type == 'neuron'",
+    obs_value_filter = "cell_type == 'neuron'"
   )
   
   test_seurat(test_args)
@@ -211,12 +211,7 @@ test_that("test_seurat_common-tissue", {
     organism = "Homo sapiens",
     measurement_name = "RNA",
     X_name = "raw",
-    obs_value_filter = "tissue == 'brain'",
-    obs_coords = NULL,
-    obs_column_names = NULL,
-    var_value_filter = NULL,
-    var_coords = NULL,
-    var_column_names = NULL
+    obs_value_filter = "tissue == 'brain'"
   )
   
   test_seurat(test_args)
@@ -233,7 +228,7 @@ test_that("test_seurat_common-tissue-large-buffer-size", {
     organism = "Homo sapiens",
     measurement_name = "RNA",
     X_name = "raw",
-    obs_value_filter = "tissue == 'brain'",
+    obs_value_filter = "tissue == 'brain'"
   )
   
   test_seurat(test_args)
@@ -249,7 +244,7 @@ test_that("test_seurat_whole-enchilada-large-buffer-size", {
     census = census,
     organism = "Homo sapiens",
     measurement_name = "RNA",
-    X_name = "raw",
+    X_name = "raw"
   )
   
   test_seurat(test_args)

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -349,16 +349,21 @@ test_that("test_seurat_common-cell-type-large-buffer-size", {
 })
 
 test_that("test_seurat_whole-enchilada-large-buffer-size", {
-              
-  census <- open_soma_latest_for_test(soma.init_buffer_bytes = paste(4 * 1024**3))
-  on.exit(census$close(), add = TRUE)
   
-  test_args <- list(
-    census = census,
-    organism = "Homo sapiens",
-    measurement_name = "RNA",
-    X_name = "raw"
-  )
+  # SKIP: R is not capable to load into memory
+  if(FALSE) {
+    census <- open_soma_latest_for_test(soma.init_buffer_bytes = paste(4 * 1024**3))
+    on.exit(census$close(), add = TRUE)
+    
+    test_args <- list(
+      census = census,
+      organism = "Homo sapiens",
+      measurement_name = "RNA",
+      X_name = "raw"
+    )
+    
+    test_seurat(test_args)
+  }
   
-  test_seurat(test_args)
+  expect_true(TRUE)
 })

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -59,47 +59,125 @@ test_that("test_incremental_query", {
   expect_true(TRUE)
 })
 
-test_that("test_seurat_small_query_human", {
+test_that("test_seurat_small-query", {
               
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
   
-  get_seurat_args(
-                  census = cenus,
-                  organism = "Homo sapiens",
-                  measurement_name = "RNA",
-                  X_name = "raw",
-                  obs_value_filter = "tissue_aorta"
-                  obs_coords = NULL,
-                  obs_column_names = NULL,
-                  var_value_filter = NULL,
-                  var_coords = NULL,
-                  var_column_names = NULL
-                  )
-                  
-  this_seurat <- do.call(get_seurat, get_seurat_args) 
+  test_args <- list(
+    census = census,
+    organism = "Homo sapiens",
+    measurement_name = "RNA",
+    X_name = "raw",
+    obs_value_filter = "tissue == 'aorta'"
+  )
+  
+  test_seurat(test_args)
+  
 })
 
-test_that("test_seurat_10K_cells_human", {
+test_that("test_seurat_10K-cells-human", {
               
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
   
-  get_seurat_args<- list(
-                  census = census,
-                  organism = "Homo sapiens",
-                  measurement_name = "RNA",
-                  X_name = "raw",
-                  obs_value_filter = NULL,
-                  obs_coords = 1:10000,
-                  obs_column_names = NULL,
-                  var_value_filter = NULL,
-                  var_coords = NULL,
-                  var_column_names = NULL
-                  )
-                  
-  this_seurat <- do.call(get_seurat, get_seurat_args) 
+  test_args <- list(
+    census = census,
+    organism = "Homo sapiens",
+    measurement_name = "RNA",
+    X_name = "raw",
+    obs_coords = 1:10000,
+  )
   
-  expect_true(is(this_seurat, "SeuratObject"))
-  expect_true(ncol(this_seurat>0))
+  test_seurat(test_args)
+                  
+})
+
+test_that("test_seurat_100K-cells-human", {
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  test_args <- list(
+    census = census,
+    organism = "Homo sapiens",
+    measurement_name = "RNA",
+    X_name = "raw",
+    obs_coords = 1:100000,
+  )
+  
+  test_seurat(test_args)
+                  
+})
+
+test_that("test_seurat_common-cell-type", {
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  test_args <- list(
+    census = census,
+    organism = "Homo sapiens",
+    measurement_name = "RNA",
+    X_name = "raw",
+    obs_value_filter = "cell_type == 'neuron'",
+  )
+  
+  test_seurat(test_args)
+                  
+})
+
+test_that("test_seurat_common-tissue", {
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  test_args <- list(
+    census = census,
+    organism = "Homo sapiens",
+    measurement_name = "RNA",
+    X_name = "raw",
+    obs_value_filter = "tissue == 'brain'",
+    obs_coords = NULL,
+    obs_column_names = NULL,
+    var_value_filter = NULL,
+    var_coords = NULL,
+    var_column_names = NULL
+  )
+  
+  test_seurat(test_args)
+                  
+})
+
+test_that("test_seurat_common-tissue-large-buffer-size", {
+              
+  census <- open_soma_latest_for_test(soma.init_buffer_bytes = paste(4 * 1024**3))
+  on.exit(census$close(), add = TRUE)
+  
+  test_args <- list(
+    census = census,
+    organism = "Homo sapiens",
+    measurement_name = "RNA",
+    X_name = "raw",
+    obs_value_filter = "tissue == 'brain'",
+  )
+  
+  test_seurat(test_args)
+                  
+})
+
+test_that("test_seurat_whole-enchilada-large-buffer-size", {
+              
+  census <- open_soma_latest_for_test(soma.init_buffer_bytes = paste(4 * 1024**3))
+  on.exit(census$close(), add = TRUE)
+  
+  test_args <- list(
+    census = census,
+    organism = "Homo sapiens",
+    measurement_name = "RNA",
+    X_name = "raw",
+  )
+  
+  test_seurat(test_args)
+                  
 })

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -152,7 +152,7 @@ test_that("test_incremental_query_human_brain", {
   
   expect_true(table_iter_is_ok(query$obs(), stop_after = 2))
   expect_true(table_iter_is_ok(query$var(), stop_after = 2))
-  expect_true(table_iter_is_ok(query$X("raw"), stop_after = 2))
+  expect_true(table_iter_is_ok(query$X("raw")$tables(), stop_after = 2))
   
 })
 
@@ -171,7 +171,7 @@ test_that("test_incremental_query_human_aorta", {
   
   expect_true(table_iter_is_ok(query$obs(), stop_after = 2))
   expect_true(table_iter_is_ok(query$var(), stop_after = 2))
-  expect_true(table_iter_is_ok(query$X("raw"), stop_after = 2))
+  expect_true(table_iter_is_ok(query$X("raw")$tables(), stop_after = 2))
   
 })
 
@@ -190,7 +190,7 @@ test_that("test_incremental_query_mouse_brain", {
   
   expect_true(table_iter_is_ok(query$obs(), stop_after = 2))
   expect_true(table_iter_is_ok(query$var(), stop_after = 2))
-  expect_true(table_iter_is_ok(query$X("raw"), stop_after = 2))
+  expect_true(table_iter_is_ok(query$X("raw")$tables(), stop_after = 2))
   
 })
 
@@ -209,7 +209,7 @@ test_that("test_incremental_query_mouse_aorta", {
   
   expect_true(table_iter_is_ok(query$obs(), stop_after = 2))
   expect_true(table_iter_is_ok(query$var(), stop_after = 2))
-  expect_true(table_iter_is_ok(query$X("raw"), stop_after = 2))
+  expect_true(table_iter_is_ok(query$X("raw")$tables(), stop_after = 2))
   
 })
 

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -90,6 +90,20 @@ test_that("test_incremental_read_X_human", {
   
 })
 
+test_that("test_incremental_read_X_human-large-buffer-size", {
+              
+  census <- open_soma_latest_for_test(soma.init_buffer_bytes = paste(4 * 1024**3))
+  on.exit(census$close(), add = TRUE)
+  
+  organism <- "homo_sapiens"
+  
+  # Warning that results cannot be concat because it 
+  # exceeds R's capability to allocate vectors beyond 32bit
+  expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables())
+  expect_true(table_iter_is_ok(X_iter))
+  
+})
+
 test_that("test_incremental_read_obs_mouse", {
               
   census <- open_soma_latest_for_test()
@@ -116,6 +130,20 @@ test_that("test_incremental_read_var_mouse", {
 test_that("test_incremental_read_X_mouse", {
               
   census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  organism <- "mus_musculus"
+  
+  # Warning that results cannot be concat because it 
+  # exceeds R's capability to allocate vectors beyond 32bit
+  expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables())
+  expect_true(table_iter_is_ok(X_iter))
+  
+})
+
+test_that("test_incremental_read_X_mouse-large-buffer-size", {
+              
+  census <- open_soma_latest_for_test(soma.init_buffer_bytes = paste(4 * 1024**3))
   on.exit(census$close(), add = TRUE)
   
   organism <- "mus_musculus"

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -86,7 +86,7 @@ test_that("test_incremental_read_X_human", {
   # Warning that results cannot be concat because it 
   # exceeds R's capability to allocate vectors beyond 32bit
   expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables())
-  expect_true(table_iter_is_ok(X_iter, stop_after = 2))
+  expect_true(table_iter_is_ok(X_iter))
   
 })
 
@@ -123,7 +123,7 @@ test_that("test_incremental_read_X_mouse", {
   # Warning that results cannot be concat because it 
   # exceeds R's capability to allocate vectors beyond 32bit
   expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables())
-  expect_true(table_iter_is_ok(X_iter, stop_after = 2))
+  expect_true(table_iter_is_ok(X_iter))
   
 })
 
@@ -252,24 +252,6 @@ test_that("test_seurat_1M-cells-human", {
                   
 })
 
-
-test_that("test_seurat_common-cell-type", {
-              
-  census <- open_soma_latest_for_test()
-  on.exit(census$close(), add = TRUE)
-  
-  test_args <- list(
-    census = census,
-    organism = "Homo sapiens",
-    measurement_name = "RNA",
-    X_name = "raw",
-    obs_value_filter = "cell_type == 'neuron'"
-  )
-  
-  test_seurat(test_args)
-                  
-})
-
 test_that("test_seurat_common-tissue", {
               
   census <- open_soma_latest_for_test()
@@ -298,6 +280,40 @@ test_that("test_seurat_common-tissue-large-buffer-size", {
     measurement_name = "RNA",
     X_name = "raw",
     obs_value_filter = "tissue == 'brain'"
+  )
+  
+  test_seurat(test_args)
+                  
+})
+
+test_that("test_seurat_common-cell-type", {
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  test_args <- list(
+    census = census,
+    organism = "Homo sapiens",
+    measurement_name = "RNA",
+    X_name = "raw",
+    obs_value_filter = "cell_type == 'neuron'"
+  )
+  
+  test_seurat(test_args)
+                  
+})
+
+test_that("test_seurat_common-cell-type-large-buffer-size", {
+              
+  census <- open_soma_latest_for_test(soma.init_buffer_bytes = paste(4 * 1024**3))
+  on.exit(census$close(), add = TRUE)
+  
+  test_args <- list(
+    census = census,
+    organism = "Homo sapiens",
+    measurement_name = "RNA",
+    X_name = "raw",
+    obs_value_filter = "cell_type == 'neuron'"
   )
   
   test_seurat(test_args)

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -1,61 +1,135 @@
 # These are expensive tests and should be run as part of the automated 
 # testing framework. They are meant to be run manually via testthat::test_file()
 
-test_that("test_load_axes", {
+test_that("test_load_obs_human", {
               
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
   
-  for (organism in c("homo_sapiens", "mus_musculus")) {
-      
-      # use subset of columns for speed
-      obs_df = census$get("census_data")$get(organism)$obs$read(coords = 1:4, column_names = c("soma_joinid", "cell_type", "tissue"))
-      obs_df = as.data.frame(obs_df$concat())
-      
-      expect_true(nrow(obs_df) > 0)
-      
-      var_df = census$get("census_data")$get(organism)$ms$get("RNA")$var$read(coords= 1:4)
-      var_df = as.data.frame(var_df$concat())
-      
-      expect_true(nrow(var_df) > 0)
-      
-      rm(obs_df)
-      rm(var_df)
-      gc()
-      break
-  }
+  organism <- "homo_sapiens"
+  
+  # use subset of columns for speed
+  obs_df = census$get("census_data")$get(organism)$obs$read(column_names = c("soma_joinid", "cell_type", "tissue"))
+  obs_df = as.data.frame(obs_df$concat())
+  expect_true(nrow(obs_df) > 0)
+})
+
+test_that("test_load_var_human", {
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  organism <- "homo_sapiens"
+  
+  var_df <- census$get("census_data")$get(organism)$ms$get("RNA")$var$read()
+  var_df <- as.data.frame(var_df$concat())
+  expect_true(nrow(var_df) > 0)
   
 })
 
-test_that("test_incremental_read", {
-              
-  # Verify that obs, var and X[raw] can be read incrementally, i.e., in chunks
+test_that("test_load_obs_mouse", {
               
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
   
-  for (organism in c("homo_sapiens", "mus_musculus")) {
-      
-      # use subset of columns for speed
-      obs_iter <- census$get("census_data")$get(organism)$obs$read(column_names = c("soma_joinid", "cell_type", "tissue"))
-      expect_true(table_iter_is_ok(obs_iter))
-      
-      var_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$var$read()
-      expect_true(table_iter_is_ok(var_iter))
-      
-      # Warning that results cannot be concat because it 
-      # exceeds R's capability to allocate vectors beyond 32bit
-      expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables())
-      
-      expect_true(table_iter_is_ok(X_iter))
-      gc()
-      break
-  }
+  organism <- "mus_musculus"
+  
+  # use subset of columns for speed
+  obs_df <- census$get("census_data")$get(organism)$obs$read(column_names = c("soma_joinid", "cell_type", "tissue"))
+  obs_df <- as.data.frame(obs_df$concat())
+  expect_true(nrow(obs_df) > 0)
+})
+
+test_that("test_load_var_mouse", {
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  organism <- "mus_musculus"
+  
+  var_df <- census$get("census_data")$get(organism)$ms$get("RNA")$var$read()
+  var_df <- as.data.frame(var_df$concat())
+  expect_true(nrow(var_df) > 0)
+  
+})
+
+test_that("test_incremental_read_obs_human", {
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  organism <- "homo_sapiens"
+  
+  # use subset of columns for speed
+  obs_iter <- census$get("census_data")$get(organism)$obs$read(column_names = c("soma_joinid", "cell_type", "tissue"))
+  expect_true(table_iter_is_ok(obs_iter))
+})
+
+test_that("test_incremental_read_var_human", {
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  organism <- "homo_sapiens"
+  
+  var_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$var$read()
+  expect_true(table_iter_is_ok(var_iter))
+})
+
+test_that("test_incremental_read_X_human", {
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  organism <- "homo_sapiens"
+  
+  # Warning that results cannot be concat because it 
+  # exceeds R's capability to allocate vectors beyond 32bit
+  expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables())
+  expect_true(table_iter_is_ok(X_iter))
+  
+})
+
+test_that("test_incremental_read_obs_mouse", {
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  organism <- "mus_musculus"
+  
+  # use subset of columns for speed
+  obs_iter <- census$get("census_data")$get(organism)$obs$read(column_names = c("soma_joinid", "cell_type", "tissue"))
+  expect_true(table_iter_is_ok(obs_iter))
+})
+
+test_that("test_incremental_read_var_mouse", {
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  organism <- "mus_musculus"
+  
+  var_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$var$read()
+  expect_true(table_iter_is_ok(var_iter))
+})
+
+test_that("test_incremental_read_X_mouse", {
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  organism <- "mus_musculus"
+  
+  # Warning that results cannot be concat because it 
+  # exceeds R's capability to allocate vectors beyond 32bit
+  expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables())
+  expect_true(table_iter_is_ok(X_iter))
   
 })
 
 test_that("test_incremental_query", {
-  #TODO implement when query$obs() $var() and $X() return iterators, not yet in tiledbsoma
+  # TODO implement when query$obs() $var() and $X() return iterators, not yet in tiledbsoma
+  # June, 2023
   expect_true(TRUE)
 })
 
@@ -179,5 +253,4 @@ test_that("test_seurat_whole-enchilada-large-buffer-size", {
   )
   
   test_seurat(test_args)
-                  
 })

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -184,6 +184,75 @@ test_that("test_seurat_100K-cells-human", {
                   
 })
 
+test_that("test_seurat_250K-cells-human", {
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  test_args <- list(
+    census = census,
+    organism = "Homo sapiens",
+    measurement_name = "RNA",
+    X_name = "raw",
+    obs_coords = 1:250000
+  )
+  
+  test_seurat(test_args)
+                  
+})
+
+test_that("test_seurat_500K-cells-human", {
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  test_args <- list(
+    census = census,
+    organism = "Homo sapiens",
+    measurement_name = "RNA",
+    X_name = "raw",
+    obs_coords = 1:500000
+  )
+  
+  test_seurat(test_args)
+                  
+})
+
+test_that("test_seurat_750K-cells-human", {
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  test_args <- list(
+    census = census,
+    organism = "Homo sapiens",
+    measurement_name = "RNA",
+    X_name = "raw",
+    obs_coords = 1:750000
+  )
+  
+  test_seurat(test_args)
+                  
+})
+
+test_that("test_seurat_1M-cells-human", {
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  test_args <- list(
+    census = census,
+    organism = "Homo sapiens",
+    measurement_name = "RNA",
+    X_name = "raw",
+    obs_coords = 1:1e6
+  )
+  
+  test_seurat(test_args)
+                  
+})
+
+
 test_that("test_seurat_common-cell-type", {
               
   census <- open_soma_latest_for_test()

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -33,27 +33,6 @@ test_that("test_incremental_read", {
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
   
-  # helper
-  table_iter_is_ok <- function(tbl_iter, stop_after = 3) {
-    
-    if (!is(tbl_iter, "TableReadIter")) return(FALSE)
-    
-    n <- 1
-    while (!tbl_iter$read_complete()) {
-      
-      if(!is.null(stop_after) & n > stop_after) break
-      
-      tbl <- tbl_iter$read_next()
-      if (!is(tbl, "Table")) return(FALSE)
-      if (!is(tbl, "ArrowTabular")) return(FALSE)
-      if (nrow(tbl) < 1) return(FALSE)
-      
-      n <- n + 1
-    }
-    
-    return(TRUE)
-  }
-  
   for (oganism in c("homo_sapiens", "mus_musculus")) {
       
       # use subset of columns for speed
@@ -70,4 +49,10 @@ test_that("test_incremental_read", {
   }
   
 })
+
+test_that("test_incremental_query", {
+  #TODO implement when query$obs() $var() and $X() return iterators, not yet in tiledbsoma
+  expect_true(TRUE)
+})
+
 

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -150,9 +150,9 @@ test_that("test_incremental_query_human_brain", {
     obs_query = SOMAAxisQuery$new(value_filter = obs_value_filter)
   )
   
-  expect_true(table_iter_is_ok(query$obs(), stop_after = 2))
-  expect_true(table_iter_is_ok(query$var(), stop_after = 2))
-  expect_true(table_iter_is_ok(query$X("raw")$tables(), stop_after = 2))
+  expect_true(table_iter_is_ok(query$obs())
+  expect_true(table_iter_is_ok(query$var())
+  expect_true(table_iter_is_ok(query$X("raw")$tables())
   
 })
 
@@ -169,9 +169,9 @@ test_that("test_incremental_query_human_aorta", {
     obs_query = SOMAAxisQuery$new(value_filter = obs_value_filter)
   )
   
-  expect_true(table_iter_is_ok(query$obs(), stop_after = 2))
-  expect_true(table_iter_is_ok(query$var(), stop_after = 2))
-  expect_true(table_iter_is_ok(query$X("raw")$tables(), stop_after = 2))
+  expect_true(table_iter_is_ok(query$obs())
+  expect_true(table_iter_is_ok(query$var())
+  expect_true(table_iter_is_ok(query$X("raw")$tables())
   
 })
 
@@ -188,9 +188,9 @@ test_that("test_incremental_query_mouse_brain", {
     obs_query = SOMAAxisQuery$new(value_filter = obs_value_filter)
   )
   
-  expect_true(table_iter_is_ok(query$obs(), stop_after = 2))
-  expect_true(table_iter_is_ok(query$var(), stop_after = 2))
-  expect_true(table_iter_is_ok(query$X("raw")$tables(), stop_after = 2))
+  expect_true(table_iter_is_ok(query$obs())
+  expect_true(table_iter_is_ok(query$var())
+  expect_true(table_iter_is_ok(query$X("raw")$tables())
   
 })
 
@@ -207,9 +207,9 @@ test_that("test_incremental_query_mouse_aorta", {
     obs_query = SOMAAxisQuery$new(value_filter = obs_value_filter)
   )
   
-  expect_true(table_iter_is_ok(query$obs(), stop_after = 2))
-  expect_true(table_iter_is_ok(query$var(), stop_after = 2))
-  expect_true(table_iter_is_ok(query$X("raw")$tables(), stop_after = 2))
+  expect_true(table_iter_is_ok(query$obs())
+  expect_true(table_iter_is_ok(query$var())
+  expect_true(table_iter_is_ok(query$X("raw")$tables())
   
 })
 

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -140,77 +140,73 @@ test_that("test_incremental_read_X_mouse-large-buffer-size", {
 test_that("test_incremental_query_human_brain", {
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   organism <- "homo_sapiens"
   obs_value_filter <- "tissue == 'brain'"
-  
+
   query <- tiledbsoma::SOMAExperimentAxisQuery$new(
     experiment = census$get("census_data")$get(organism),
-    measurement_name = "RNA", 
+    measurement_name = "RNA",
     obs_query = tiledbsoma::SOMAAxisQuery$new(value_filter = obs_value_filter)
   )
-  
+
   expect_true(table_iter_is_ok(query$obs()))
   expect_true(table_iter_is_ok(query$var()))
   expect_true(table_iter_is_ok(query$X("raw")$tables()))
-  
 })
 
 test_that("test_incremental_query_human_aorta", {
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   organism <- "homo_sapiens"
   obs_value_filter <- "tissue == 'aorta'"
-  
+
   query <- tiledbsoma::SOMAExperimentAxisQuery$new(
     experiment = census$get("census_data")$get(organism),
-    measurement_name = "RNA", 
+    measurement_name = "RNA",
     obs_query = tiledbsoma::SOMAAxisQuery$new(value_filter = obs_value_filter)
   )
-  
+
   expect_true(table_iter_is_ok(query$obs()))
   expect_true(table_iter_is_ok(query$var()))
   expect_true(table_iter_is_ok(query$X("raw")$tables()))
-  
 })
 
 test_that("test_incremental_query_mouse_brain", {
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   organism <- "mus_musculus"
   obs_value_filter <- "tissue == 'brain'"
-  
+
   query <- tiledbsoma::SOMAExperimentAxisQuery$new(
     experiment = census$get("census_data")$get(organism),
-    measurement_name = "RNA", 
+    measurement_name = "RNA",
     obs_query = tiledbsoma::SOMAAxisQuery$new(value_filter = obs_value_filter)
   )
-  
+
   expect_true(table_iter_is_ok(query$obs()))
   expect_true(table_iter_is_ok(query$var()))
   expect_true(table_iter_is_ok(query$X("raw")$tables()))
-  
 })
 
 test_that("test_incremental_query_mouse_aorta", {
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
-  
+
   organism <- "mus_musculus"
   obs_value_filter <- "tissue == 'aorta'"
-  
+
   query <- tiledbsoma::SOMAExperimentAxisQuery$new(
     experiment = census$get("census_data")$get(organism),
-    measurement_name = "RNA", 
+    measurement_name = "RNA",
     obs_query = tiledbsoma::SOMAAxisQuery$new(value_filter = obs_value_filter)
   )
-  
+
   expect_true(table_iter_is_ok(query$obs()))
   expect_true(table_iter_is_ok(query$var()))
   expect_true(table_iter_is_ok(query$X("raw")$tables()))
-  
 })
 
 test_that("test_seurat_small-query", {

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -86,7 +86,7 @@ test_that("test_incremental_read_X_human", {
   # Warning that results cannot be concat because it 
   # exceeds R's capability to allocate vectors beyond 32bit
   expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables())
-  expect_true(table_iter_is_ok(X_iter))
+  expect_true(table_iter_is_ok(X_iter, stop_after = 2))
   
 })
 
@@ -123,7 +123,7 @@ test_that("test_incremental_read_X_mouse", {
   # Warning that results cannot be concat because it 
   # exceeds R's capability to allocate vectors beyond 32bit
   expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables())
-  expect_true(table_iter_is_ok(X_iter))
+  expect_true(table_iter_is_ok(X_iter, stop_after = 2))
   
 })
 

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -1,0 +1,73 @@
+# These are expensive tests and should be run as part of the automated 
+# testing framework. They are meant to be run manually via testthat::test_file()
+
+test_that("test_load_axes", {
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  for (oganism in c("homo_sapiens", "mus_musculus")) {
+      
+      # use subset of columns for speed
+      obs_df = census$get("census_data")$get(organism)$obs$read(coords = 1:4, column_names = c("soma_joinid", "cell_type", "tissue"))
+      obs_df = as.data.frame(obs_df$concat())
+      
+      expect_true(nrow(obs_df) > 0)
+      
+      var_df = census$get("census_data")$get(organism)$ms$get("RNA")$var$read(coords= 1:4)
+      var_df = as.data.frame(var_df$concat())
+      
+      expect_true(nrow(var_df) > 0)
+      
+      rm(obs_df)
+      rm(var_df)
+      gc()
+  }
+  
+})
+
+test_that("test_incremental_read", {
+              
+  # Verify that obs, var and X[raw] can be read incrementally, i.e., in chunks
+              
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  # helper
+  table_iter_is_ok <- function(tbl_iter, stop_after = 3) {
+    
+    if (!is(tbl_iter, "TableReadIter")) return(FALSE)
+    
+    n <- 1
+    while (!tbl_iter$read_complete()) {
+      
+      if(!is.null(stop_after) & n > stop_after) break
+      
+      tbl <- tbl_iter$read_next()
+      if (!is(tbl, "Table")) return(FALSE)
+      if (!is(tbl, "ArrowTabular")) return(FALSE)
+      if (nrow(tbl) < 1) return(FALSE)
+      
+      n <- n + 1
+    }
+    
+    return(TRUE)
+  }
+  
+  for (oganism in c("homo_sapiens", "mus_musculus")) {
+      
+      # use subset of columns for speed
+      obs_iter <- census$get("census_data")$get(organism)$obs$read(column_names = c("soma_joinid", "cell_type", "tissue"))
+      expect_true(table_iter_is_ok(obs_iter))
+      
+      var_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$var$read()
+      expect_true(table_iter_is_ok(var_iter))
+      
+      expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables(),
+                    "Iteration results cannot be concatenated on its entirety because array has non-zero elements greater than '.Machine$integer.max'")
+      expect_true(table_iter_is_ok(X_iter))
+      gc()
+  }
+  
+})
+

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -68,6 +68,27 @@ test_that("test_incremental_read_var_human", {
   expect_true(table_iter_is_ok(var_iter))
 })
 
+test_that("test_incremental_read_obs_mouse", {
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+
+  organism <- "mus_musculus"
+
+  # use subset of columns for speed
+  obs_iter <- census$get("census_data")$get(organism)$obs$read(column_names = c("soma_joinid", "cell_type", "tissue"))
+  expect_true(table_iter_is_ok(obs_iter))
+})
+
+test_that("test_incremental_read_var_mouse", {
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+
+  organism <- "mus_musculus"
+
+  var_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$var$read()
+  expect_true(table_iter_is_ok(var_iter))
+})
+
 test_that("test_incremental_read_X_human", {
   census <- open_soma_latest_for_test()
   on.exit(census$close(), add = TRUE)
@@ -90,27 +111,6 @@ test_that("test_incremental_read_X_human-large-buffer-size", {
   # exceeds R's capability to allocate vectors beyond 32bit
   X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables()
   expect_true(table_iter_is_ok(X_iter))
-})
-
-test_that("test_incremental_read_obs_mouse", {
-  census <- open_soma_latest_for_test()
-  on.exit(census$close(), add = TRUE)
-
-  organism <- "mus_musculus"
-
-  # use subset of columns for speed
-  obs_iter <- census$get("census_data")$get(organism)$obs$read(column_names = c("soma_joinid", "cell_type", "tissue"))
-  expect_true(table_iter_is_ok(obs_iter))
-})
-
-test_that("test_incremental_read_var_mouse", {
-  census <- open_soma_latest_for_test()
-  on.exit(census$close(), add = TRUE)
-
-  organism <- "mus_musculus"
-
-  var_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$var$read()
-  expect_true(table_iter_is_ok(var_iter))
 })
 
 test_that("test_incremental_read_X_mouse", {

--- a/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
+++ b/api/r/cellxgene.census/tests/testthat/acceptance-tests.R
@@ -76,7 +76,7 @@ test_that("test_incremental_read_X_human", {
 
   # Warning that results cannot be concat because it
   # exceeds R's capability to allocate vectors beyond 32bit
-  expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables())
+  X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables()
   expect_true(table_iter_is_ok(X_iter))
 })
 
@@ -88,7 +88,7 @@ test_that("test_incremental_read_X_human-large-buffer-size", {
 
   # Warning that results cannot be concat because it
   # exceeds R's capability to allocate vectors beyond 32bit
-  expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables())
+  X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables()
   expect_true(table_iter_is_ok(X_iter))
 })
 
@@ -121,7 +121,7 @@ test_that("test_incremental_read_X_mouse", {
 
   # Warning that results cannot be concat because it
   # exceeds R's capability to allocate vectors beyond 32bit
-  expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables())
+  X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables()
   expect_true(table_iter_is_ok(X_iter))
 })
 
@@ -133,14 +133,84 @@ test_that("test_incremental_read_X_mouse-large-buffer-size", {
 
   # Warning that results cannot be concat because it
   # exceeds R's capability to allocate vectors beyond 32bit
-  expect_warning(X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables())
+  X_iter <- census$get("census_data")$get(organism)$ms$get("RNA")$X$get("raw")$read()$tables()
   expect_true(table_iter_is_ok(X_iter))
 })
 
-test_that("test_incremental_query", {
-  # TODO implement when query$obs() $var() and $X() return iterators, not yet in tiledbsoma
-  # June, 2023
-  expect_true(TRUE)
+test_that("test_incremental_query_human_brain", {
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  organism <- "homo_sapiens"
+  obs_value_filter <- "tissue == 'brain'"
+  
+  query <- tiledbsoma::SOMAExperimentAxisQuery$new(
+    experiment = census$get("census_data")$get(organism),
+    measurement_name = "RNA", 
+    obs_query = SOMAAxisQuery$new(value_filter = obs_value_filter)
+  )
+  
+  expect_true(table_iter_is_ok(query$obs(), stop_after = 2))
+  expect_true(table_iter_is_ok(query$var(), stop_after = 2))
+  expect_true(table_iter_is_ok(query$X("raw"), stop_after = 2))
+  
+})
+
+test_that("test_incremental_query_human_aorta", {
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  organism <- "homo_sapiens"
+  obs_value_filter <- "tissue == 'aorta'"
+  
+  query <- tiledbsoma::SOMAExperimentAxisQuery$new(
+    experiment = census$get("census_data")$get(organism),
+    measurement_name = "RNA", 
+    obs_query = SOMAAxisQuery$new(value_filter = obs_value_filter)
+  )
+  
+  expect_true(table_iter_is_ok(query$obs(), stop_after = 2))
+  expect_true(table_iter_is_ok(query$var(), stop_after = 2))
+  expect_true(table_iter_is_ok(query$X("raw"), stop_after = 2))
+  
+})
+
+test_that("test_incremental_query_mouse_brain", {
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  organism <- "mus_musculus"
+  obs_value_filter <- "tissue == 'brain'"
+  
+  query <- tiledbsoma::SOMAExperimentAxisQuery$new(
+    experiment = census$get("census_data")$get(organism),
+    measurement_name = "RNA", 
+    obs_query = SOMAAxisQuery$new(value_filter = obs_value_filter)
+  )
+  
+  expect_true(table_iter_is_ok(query$obs(), stop_after = 2))
+  expect_true(table_iter_is_ok(query$var(), stop_after = 2))
+  expect_true(table_iter_is_ok(query$X("raw"), stop_after = 2))
+  
+})
+
+test_that("test_incremental_query_mouse_aorta", {
+  census <- open_soma_latest_for_test()
+  on.exit(census$close(), add = TRUE)
+  
+  organism <- "mus_musculus"
+  obs_value_filter <- "tissue == 'aorta'"
+  
+  query <- tiledbsoma::SOMAExperimentAxisQuery$new(
+    experiment = census$get("census_data")$get(organism),
+    measurement_name = "RNA", 
+    obs_query = SOMAAxisQuery$new(value_filter = obs_value_filter)
+  )
+  
+  expect_true(table_iter_is_ok(query$obs(), stop_after = 2))
+  expect_true(table_iter_is_ok(query$var(), stop_after = 2))
+  expect_true(table_iter_is_ok(query$X("raw"), stop_after = 2))
+  
 })
 
 test_that("test_seurat_small-query", {

--- a/api/r/cellxgene.census/tests/testthat/helper-acceptance.R
+++ b/api/r/cellxgene.census/tests/testthat/helper-acceptance.R
@@ -29,5 +29,5 @@ table_iter_is_ok <- function(tbl_iter, stop_after = NULL) {
 test_seurat <- function(get_seurat_args) {
   this_seurat <- do.call(get_seurat, get_seurat_args) 
   expect_true(is(this_seurat, "Seurat"))
-  expect_true(ncol(this_seurat>0))
+  expect_true(ncol(this_seurat) > 0)
 }

--- a/api/r/cellxgene.census/tests/testthat/helper-acceptance.R
+++ b/api/r/cellxgene.census/tests/testthat/helper-acceptance.R
@@ -1,24 +1,27 @@
 table_iter_is_ok <- function(tbl_iter, stop_after = NULL) {
-
-  if (!is(tbl_iter, "TableReadIter")) 
+  if (!is(tbl_iter, "TableReadIter")) {
     return(FALSE)
+  }
 
   n <- 1
   while (!tbl_iter$read_complete()) {
-    
-    if(!is.null(stop_after)) {
-      if (n > stop_after)
+    if (!is.null(stop_after)) {
+      if (n > stop_after) {
         break
+      }
     }
-    
+
     tbl <- tbl_iter$read_next()
-    if (!is(tbl, "Table")) 
+    if (!is(tbl, "Table")) {
       return(FALSE)
-    if (!is(tbl, "ArrowTabular")) 
+    }
+    if (!is(tbl, "ArrowTabular")) {
       return(FALSE)
-    if (nrow(tbl) < 1) 
+    }
+    if (nrow(tbl) < 1) {
       return(FALSE)
-    
+    }
+
     n <- n + 1
   }
 
@@ -27,7 +30,7 @@ table_iter_is_ok <- function(tbl_iter, stop_after = NULL) {
 
 # Tests that the object from get_seurat is a non-empty Seurat object
 test_seurat <- function(get_seurat_args) {
-  this_seurat <- do.call(get_seurat, get_seurat_args) 
+  this_seurat <- do.call(get_seurat, get_seurat_args)
   expect_true(is(this_seurat, "Seurat"))
   expect_true(ncol(this_seurat) > 0)
 }

--- a/api/r/cellxgene.census/tests/testthat/helper-acceptance.R
+++ b/api/r/cellxgene.census/tests/testthat/helper-acceptance.R
@@ -28,6 +28,6 @@ table_iter_is_ok <- function(tbl_iter, stop_after = NULL) {
 # Tests that the object from get_seurat is a non-empty Seurat object
 test_seurat <- function(get_seurat_args) {
   this_seurat <- do.call(get_seurat, get_seurat_args) 
-  expect_true(is(this_seurat, "SeuratObject"))
+  expect_true(is(this_seurat, "Seurat"))
   expect_true(ncol(this_seurat>0))
 }

--- a/api/r/cellxgene.census/tests/testthat/helper-acceptance.R
+++ b/api/r/cellxgene.census/tests/testthat/helper-acceptance.R
@@ -1,21 +1,28 @@
-table_iter_is_ok <- function(tbl_iter, stop_after = 1) {
+table_iter_is_ok <- function(tbl_iter, stop_after = NULL) {
 
-if (!is(tbl_iter, "TableReadIter")) return(FALSE)
+  if (!is(tbl_iter, "TableReadIter")) 
+    return(FALSE)
 
-n <- 1
-while (!tbl_iter$read_complete()) {
-  
-  if(!is.null(stop_after) & n > stop_after) break
-  
-  tbl <- tbl_iter$read_next()
-  if (!is(tbl, "Table")) return(FALSE)
-  if (!is(tbl, "ArrowTabular")) return(FALSE)
-  if (nrow(tbl) < 1) return(FALSE)
-  
-  n <- n + 1
-}
+  n <- 1
+  while (!tbl_iter$read_complete()) {
+    
+    if(!is.null(stop_after)) {
+      if (n > stop_after)
+        break
+    }
+    
+    tbl <- tbl_iter$read_next()
+    if (!is(tbl, "Table")) 
+      return(FALSE)
+    if (!is(tbl, "ArrowTabular")) 
+      return(FALSE)
+    if (nrow(tbl) < 1) 
+      return(FALSE)
+    
+    n <- n + 1
+  }
 
-return(TRUE)
+  return(TRUE)
 }
 
 # Tests that the object from get_seurat is a non-empty Seurat object

--- a/api/r/cellxgene.census/tests/testthat/helper-acceptance.R
+++ b/api/r/cellxgene.census/tests/testthat/helper-acceptance.R
@@ -17,3 +17,10 @@ while (!tbl_iter$read_complete()) {
 
 return(TRUE)
 }
+
+# Tests that the object from get_seurat is a non-empty Seurat object
+test_seurat <- function(get_seurat_args) {
+  this_seurat <- do.call(get_seurat, get_seurat_args) 
+  expect_true(is(this_seurat, "SeuratObject"))
+  expect_true(ncol(this_seurat>0))
+}

--- a/api/r/cellxgene.census/tests/testthat/helper-acceptance.R
+++ b/api/r/cellxgene.census/tests/testthat/helper-acceptance.R
@@ -1,0 +1,19 @@
+table_iter_is_ok <- function(tbl_iter, stop_after = 1) {
+
+if (!is(tbl_iter, "TableReadIter")) return(FALSE)
+
+n <- 1
+while (!tbl_iter$read_complete()) {
+  
+  if(!is.null(stop_after) & n > stop_after) break
+  
+  tbl <- tbl_iter$read_next()
+  if (!is(tbl, "Table")) return(FALSE)
+  if (!is(tbl, "ArrowTabular")) return(FALSE)
+  if (nrow(tbl) < 1) return(FALSE)
+  
+  n <- n + 1
+}
+
+return(TRUE)
+}

--- a/api/r/cellxgene.census/tests/testthat/helper-open_soma.R
+++ b/api/r/cellxgene.census/tests/testthat/helper-open_soma.R
@@ -4,14 +4,15 @@
 
 tiledbsoma_ctx_latest_for_test <- NULL
 
-open_soma_latest_for_test <- function() {
+open_soma_latest_for_test <- function(...) {
   if (is.null(tiledbsoma_ctx_latest_for_test)) {
     # it's important to initialize tiledbsoma_ctx_latest_for_test "lazily" here
     # rather than at top level since top-level code is evaluated at install time
     # and saved, which leads to confusion with TileDB-R's internal caching of
     # the last-used context.
     tiledbsoma_ctx_latest_for_test <- new_SOMATileDBContext_for_census(
-      get_census_version_description("latest")
+      get_census_version_description("latest"),
+      ...
     )
   }
   open_soma("latest", tiledbsoma_ctx = tiledbsoma_ctx_latest_for_test)


### PR DESCRIPTION
- Addresses #190 
- Also updates python acceptance tests:
   - Decomposes certain "parametrized" tests into individual test -- this allows for easy 1:1 running time comparisons to R tests.
   - Adds a few tests to increase granularity in reading logs 
