### PR TITLE
Remove python 3.7 support

### DIFF
--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -12,10 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        exclude:
-          - os: macos-latest
-            python-version: 3.7
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{matrix.os}}
 
@@ -25,14 +22,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies (excluding experimental)
-        if: matrix.python-version == '3.7'
-        run: |
-          python -m pip install -U pip setuptools wheel
-          pip install -r ./api/python/cellxgene_census/scripts/requirements-dev.txt
-          pip install -e './api/python/cellxgene_census/'
       - name: Install dependencies (including experimental)
-        if: matrix.python-version != '3.7'
         run: |
           python -m pip install -U pip setuptools wheel
           pip install -r ./api/python/cellxgene_census/scripts/requirements-dev.txt
@@ -41,7 +31,6 @@ jobs:
         run: |
           PYTHONPATH=. coverage run --parallel-mode -m pytest -v -rP --durations=20 ./api/python/cellxgene_census/tests/
       - name: Test with pytest (API, experimental)
-        if: matrix.python-version != '3.7'
         run: |
           PYTHONPATH=. coverage run --parallel-mode -m pytest -v -rP --durations=20 --experimental ./api/python/cellxgene_census/tests/experimental
       - uses: actions/upload-artifact@v3

--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -37,7 +37,7 @@ dependencies= [
     "requests",
     "typing_extensions",
     "s3fs>=2021.06.1",
-    "scipy==1.10.1",
+    "scipy<1.11",  # work around incompatibility between scipy and pyarrow
     # Temporary fix for Mac OSX, to be removed by https://github.com/chanzuckerberg/cellxgene-census/issues/415
     "certifi",
 ]

--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">= 3.7, < 3.12"
+requires-python = ">= 3.8, < 3.12"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -22,7 +22,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -32,13 +31,13 @@ dependencies= [
     # NOTE: the tiledbsoma version must be >= to the version used in the Census builder, to
     # ensure that the assets are readable (tiledbsoma supports backward compatible reading).
     # Make sure this version does not fall behind the builder's tiledbsoma version.
-    "tiledbsoma==1.2.5",
+    "tiledbsoma==1.2.7",
     "anndata",
     "numpy>=1.21,<1.25",  # numpy is constrained by numba and the old pip solver
     "requests",
     "typing_extensions",
     "s3fs>=2021.06.1",
-    "scipy",
+    "scipy~=1.10",
     # Temporary fix for Mac OSX, to be removed by https://github.com/chanzuckerberg/cellxgene-census/issues/415
     "certifi",
 ]

--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -37,7 +37,7 @@ dependencies= [
     "requests",
     "typing_extensions",
     "s3fs>=2021.06.1",
-    "scipy~=1.10",
+    "scipy==1.10.1",
     # Temporary fix for Mac OSX, to be removed by https://github.com/chanzuckerberg/cellxgene-census/issues/415
     "certifi",
 ]

--- a/api/python/cellxgene_census/src/cellxgene_census/__init__.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/__init__.py
@@ -20,11 +20,7 @@ For more information on the API, visit the `cellxgene_census repo`_. For more in
     https://github.com/single-cell-data/TileDB-SOMA
 """
 
-try:
-    from importlib import metadata
-except ImportError:
-    # for python <=3.7
-    import importlib_metadata as metadata  # type: ignore[no-redef]
+from importlib import metadata
 
 from ._get_anndata import get_anndata
 from ._open import download_source_h5ad, get_source_h5ad_uri, open_soma

--- a/api/python/notebooks/README.md
+++ b/api/python/notebooks/README.md
@@ -8,7 +8,7 @@ Demonstration notebooks for the CZ CELLxGENE Discover Census. There are two kind
 ## Dependencies
 
 You must be on a Linux or MacOS system, with the following installed:
-* Python 3.7 to 3.11
+* Python 3.8 to 3.11
 * Jupyter or some other means of running notebooks (e.g., vscode)
 
 For now, it is recommended that you do all this on a host with sufficient memory,

--- a/docs/cellxgene_census_docsite_installation.md
+++ b/docs/cellxgene_census_docsite_installation.md
@@ -4,7 +4,7 @@
 
 The Census API requires a Linux or MacOS system with:
 
-- Python 3.7 to Python 3.10. Or R, supported versions TBD.
+- Python 3.8 to Python 3.11. Or R, supported versions TBD.
 - Recommended: >16 GB of memory.
 - Recommended: >5 Mbps internet connection. 
 - Recommended: for increased performance use the API through a AWS-EC2 instance from the region `us-west-2`. The Census data builds are hosted in a AWS-S3 bucket in that region.

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -6,7 +6,7 @@ Dependencies
 
 You must be on a Linux or MacOS system, with the following installed:
 
-- Python 3.7 to 3.11
+- Python 3.8 to 3.11
 - Jupyter or some other means of running notebooks (e.g., vscode)
 
 For now, it is recommended that you do all this on a host with sufficient memory,

--- a/tools/cellxgene_census_builder/pyproject.toml
+++ b/tools/cellxgene_census_builder/pyproject.toml
@@ -63,7 +63,7 @@ root = "../.."
 
 [tool.black]
 line-length = 120
-target_version = ['py10']
+target_version = ['py310']
 
 [tool.mypy]
 show_error_codes = true

--- a/tools/cellxgene_census_builder/pyproject.toml
+++ b/tools/cellxgene_census_builder/pyproject.toml
@@ -35,7 +35,7 @@ dependencies= [
     # IMPORTANT: consider TileDB format compat before advancing this version.
     # IMPORTANT: do not update to cellxgene_census package until you want a new tiledbsoma/tiledb
     "cell_census==0.10.0", 
-    "scipy~=1.10",
+    "scipy==1.10.1",
     "fsspec",
     "s3fs",
     "requests",

--- a/tools/cellxgene_census_builder/pyproject.toml
+++ b/tools/cellxgene_census_builder/pyproject.toml
@@ -35,7 +35,7 @@ dependencies= [
     # IMPORTANT: consider TileDB format compat before advancing this version.
     # IMPORTANT: do not update to cellxgene_census package until you want a new tiledbsoma/tiledb
     "cell_census==0.10.0", 
-    "scipy",
+    "scipy~=1.10",
     "fsspec",
     "s3fs",
     "requests",

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target_version = ['py10']
+target_version = ['py310']
 
 [tool.mypy]
 show_error_codes = true

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target_version = ['py39']
+target_version = ['py10']
 
 [tool.mypy]
 show_error_codes = true


### PR DESCRIPTION
Fixes #577 
Fixes #564 

Changes:
* Remove support for Python 3.7
* Update tiledbsoma pin to 1.2.7 (latest)
* Pins scipy version to work around pyarrow incompat with latest
