### PR TITLE
[r] install tiledbsoma from github

### DIFF
--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -25,7 +25,7 @@ jobs:
         # Install the latest tiledbsoma package, overwriting any version cached by
         # setup-r-dependencies. TODO: once there are release versions, set up a build matrix with
         # both the released and latest versions.
-        run: Rscript -e 'remotes::install_github("https://github.com/single-cell-data/TileDB-SOMA", subdir="apis/r")'
+        run: Rscript -e 'remotes::install_git("https://github.com/single-cell-data/TileDB-SOMA.git", subdir="apis/r")'
       - name: styler
         run: Rscript -e 'library("styler"); style_pkg("api/r/cellxgene.census", dry="fail")'
       - name: check session info

--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -21,11 +21,11 @@ jobs:
           working-directory: ./api/r/cellxgene.census
           extra-packages: any::rcmdcheck, any::styler, any::roxygen2
           cache: true
-      - name: install tiledbsoma & tiledb from tiledb-inc.r-universe.dev
-        # Install the latest tiledb[soma] package, overwriting any version cached by
-        # setup-r-dependencies. FIXME once we have a strategy for
-        # https://github.com/single-cell-data/TileDB-SOMA/issues/1427
-        run: Rscript -e 'install.packages(c("tiledb", "tiledbsoma"), repos = "https://tiledb-inc.r-universe.dev")'
+      - name: install tiledbsoma
+        # Install the latest tiledbsoma package, overwriting any version cached by
+        # setup-r-dependencies. TODO: once there are release versions, set up a build matrix with
+        # both the released and latest versions.
+        run: Rscript -e 'remotes::install_github("https://github.com/single-cell-data/TileDB-SOMA", subdir="apis/r")'
       - name: styler
         run: Rscript -e 'library("styler"); style_pkg("api/r/cellxgene.census", dry="fail")'
       - name: check session info

--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           working-directory: ./api/r/cellxgene.census
-          extra-packages: any::rcmdcheck, any::styler, any::roxygen2
+          extra-packages: any::rcmdcheck, any::styler, any::roxygen2, any::remotes
           cache: true
       - name: install tiledbsoma
         # Install the latest tiledbsoma package, overwriting any version cached by


### PR DESCRIPTION
Install the latest tiledbsoma from github, while we're still finalizing the r-universe release process: https://github.com/single-cell-data/TileDB-SOMA/issues/1427
