### PR TITLE
add sparse iterator to experimental.utils

### DIFF
--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/util/__init__.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/util/__init__.py
@@ -1,6 +1,8 @@
+from cellxgene_census.experimental.util._csr_iter import X_sparse_iter
 from cellxgene_census.experimental.util._eager_iter import EagerBufferedIterator, EagerIterator
 
 __all__ = [
     "EagerIterator",
     "EagerBufferedIterator",
+    "X_sparse_iter",
 ]

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/util/_csr_iter.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/util/_csr_iter.py
@@ -55,14 +55,14 @@ def X_sparse_iter(
     Examples:
         >>> with cellxgene_census.open_soma() as census:
         ...     exp = census["census_data"][experiment]
-        ...    with exp.axis_query(measurement_name="RNA") as query:
-        ...        for (obs_soma_joinids, var_soma_joinids), X_chunk in X_sparse_iter(
-        ...            query, X_name="raw", stride=1000
-        ...        ):
-        ...            # X_chunk is a scipy.csr_matrix of csc_matrix
-        ...            # For each X_chunk[i, j], the associated soma_joinid is
-        ...            # obs_soma_joinids[i] and var_soma_joinids[j]
-        ...            ...
+        ...     with exp.axis_query(measurement_name="RNA") as query:
+        ...         for (obs_soma_joinids, var_soma_joinids), X_chunk in X_sparse_iter(
+        ...             query, X_name="raw", stride=1000
+        ...         ):
+        ...             # X_chunk is a scipy.csr_matrix of csc_matrix
+        ...             # For each X_chunk[i, j], the associated soma_joinid is
+        ...             # obs_soma_joinids[i] and var_soma_joinids[j]
+        ...             ...
 
     Lifecycle:
         experimental

--- a/api/python/cellxgene_census/tests/experimental/util/test_csr_iter.py
+++ b/api/python/cellxgene_census/tests/experimental/util/test_csr_iter.py
@@ -22,7 +22,7 @@ def small_mem_context() -> soma.SOMATileDBContext:
 @pytest.mark.experimental
 @pytest.mark.live_corpus
 def test_X_sparse_iter(small_mem_context: soma.SOMATileDBContext) -> None:
-    with cellxgene_census.open_soma(census_version="stable", context=small_mem_context) as census:
+    with cellxgene_census.open_soma(census_version="latest", context=small_mem_context) as census:
         obs_filter = """is_primary_data == True and tissue_general == 'tongue'"""
         with census["census_data"]["mus_musculus"].axis_query(
             measurement_name="RNA", obs_query=soma.AxisQuery(value_filter=obs_filter)
@@ -38,7 +38,7 @@ def test_X_sparse_iter(small_mem_context: soma.SOMATileDBContext) -> None:
 @pytest.mark.experimental
 @pytest.mark.live_corpus
 def test_X_sparse_iter_unsupported(small_mem_context: soma.SOMATileDBContext) -> None:
-    with cellxgene_census.open_soma(census_version="stable", context=small_mem_context) as census:
+    with cellxgene_census.open_soma(census_version="latest", context=small_mem_context) as census:
         with census["census_data"]["mus_musculus"].axis_query(measurement_name="RNA") as query:
             with pytest.raises(ValueError):
                 next(X_sparse_iter(query, axis=1))

--- a/api/python/cellxgene_census/tests/experimental/util/test_csr_iter.py
+++ b/api/python/cellxgene_census/tests/experimental/util/test_csr_iter.py
@@ -1,9 +1,9 @@
-import pytest
-
-import cellxgene_census
 import numpy as np
+import pytest
 import scipy.sparse as sparse
 import tiledbsoma as soma
+
+import cellxgene_census
 from cellxgene_census.experimental.util import X_sparse_iter
 
 
@@ -22,9 +22,7 @@ def small_mem_context() -> soma.SOMATileDBContext:
 @pytest.mark.experimental
 @pytest.mark.live_corpus
 def test_X_sparse_iter(small_mem_context: soma.SOMATileDBContext) -> None:
-    with cellxgene_census.open_soma(
-        census_version="stable", context=small_mem_context
-    ) as census:
+    with cellxgene_census.open_soma(census_version="stable", context=small_mem_context) as census:
         obs_filter = """is_primary_data == True and tissue_general == 'tongue'"""
         with census["census_data"]["mus_musculus"].axis_query(
             measurement_name="RNA", obs_query=soma.AxisQuery(value_filter=obs_filter)
@@ -40,14 +38,10 @@ def test_X_sparse_iter(small_mem_context: soma.SOMATileDBContext) -> None:
 @pytest.mark.experimental
 @pytest.mark.live_corpus
 def test_X_sparse_iter_unsupported(small_mem_context: soma.SOMATileDBContext) -> None:
-    with cellxgene_census.open_soma(
-        census_version="stable", context=small_mem_context
-    ) as census:
-        with census["census_data"]["mus_musculus"].axis_query(
-            measurement_name="RNA"
-        ) as query:
+    with cellxgene_census.open_soma(census_version="stable", context=small_mem_context) as census:
+        with census["census_data"]["mus_musculus"].axis_query(measurement_name="RNA") as query:
             with pytest.raises(ValueError):
                 next(X_sparse_iter(query, axis=1))
 
             with pytest.raises(ValueError):
-                next(X_sparse_iter(query, fmt="foobar"))
+                next(X_sparse_iter(query, fmt="foobar"))  # type: ignore[arg-type]

--- a/api/python/cellxgene_census/tests/experimental/util/test_csr_iter.py
+++ b/api/python/cellxgene_census/tests/experimental/util/test_csr_iter.py
@@ -1,0 +1,53 @@
+import pytest
+
+import cellxgene_census
+import numpy as np
+import scipy.sparse as sparse
+import tiledbsoma as soma
+from cellxgene_census.experimental.util import X_sparse_iter
+
+
+@pytest.fixture
+def small_mem_context() -> soma.SOMATileDBContext:
+    """used to keep memory usage smaller for GHA runners."""
+    cfg = {
+        "tiledb_config": {
+            "soma.init_buffer_bytes": 32 * 1024**2,
+            "vfs.s3.no_sign_request": True,
+        },
+    }
+    return soma.SOMATileDBContext().replace(**cfg)
+
+
+@pytest.mark.experimental
+@pytest.mark.live_corpus
+def test_X_sparse_iter(small_mem_context: soma.SOMATileDBContext) -> None:
+    with cellxgene_census.open_soma(
+        census_version="stable", context=small_mem_context
+    ) as census:
+        obs_filter = """is_primary_data == True and tissue_general == 'tongue'"""
+        with census["census_data"]["mus_musculus"].axis_query(
+            measurement_name="RNA", obs_query=soma.AxisQuery(value_filter=obs_filter)
+        ) as query:
+            for (obs_ids, var_ids), X_chunk in X_sparse_iter(query, fmt="csr"):
+                assert X_chunk.shape[0] == len(obs_ids)
+                assert X_chunk.shape[1] == len(var_ids)
+                assert obs_ids.dtype == np.int64
+                assert var_ids.dtype == np.int64
+                assert sparse.isspmatrix_csr(X_chunk)
+
+
+@pytest.mark.experimental
+@pytest.mark.live_corpus
+def test_X_sparse_iter_unsupported(small_mem_context: soma.SOMATileDBContext) -> None:
+    with cellxgene_census.open_soma(
+        census_version="stable", context=small_mem_context
+    ) as census:
+        with census["census_data"]["mus_musculus"].axis_query(
+            measurement_name="RNA"
+        ) as query:
+            with pytest.raises(ValueError):
+                next(X_sparse_iter(query, axis=1))
+
+            with pytest.raises(ValueError):
+                next(X_sparse_iter(query, fmt="foobar"))

--- a/tools/cell_dup_check/finddups.ipynb
+++ b/tools/cell_dup_check/finddups.ipynb
@@ -34,7 +34,7 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
-    "from _csr_iter import X_sparse_iter\n",
+    "from cellxgene_census.experimental.util import X_sparse_iter\n",
     "\n",
     "\n",
     "\"\"\"\n",

--- a/tools/cell_dup_check/finddups.ipynb
+++ b/tools/cell_dup_check/finddups.ipynb
@@ -114,7 +114,7 @@
     "        hashes = pd.Series(data=np.full((len(obs_df),), \"\"), index=obs_df.index)\n",
     "\n",
     "        for (obs_soma_joinids_chunk, _), X_chunk in X_sparse_iter(\n",
-    "            query, X_name=\"raw\", row_stride=row_stride\n",
+    "            query, X_name=\"raw\", stride=row_stride\n",
     "        ):\n",
     "            for r, row_soma_joinid in enumerate(obs_soma_joinids_chunk):\n",
     "                X_row = X_chunk.getrow(r)\n",


### PR DESCRIPTION
Add a new experimental API to iterate over X array returning Scipy sparse CSR or CSC matrix.
Update the finddups notebook to use it

Prototype for single-cell-data/TileDB-SOMA#1503
