### PR TITLE
Adds sparse iter reference docs to doc-site

### DIFF
--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -60,3 +60,11 @@ Experimental: Processing
 
     cellxgene_census.experimental.pp.get_highly_variable_genes
     cellxgene_census.experimental.pp.highly_variable_genes
+    
+Experimental: Utility
+--------------------------------
+.. autosummary::
+    :toctree: _autosummary/
+    :nosignatures:
+
+    cellxgene_census.experimental.util.X_sparse_iter


### PR DESCRIPTION
Results in this:

<img width="1205" alt="image" src="https://github.com/chanzuckerberg/cellxgene-census/assets/29237819/7ad2d002-07fe-47e2-98ab-e23ffa6a6c9c">
