### PR TITLE
change error handling for /curation REST errors

### DIFF
--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/anndata.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/anndata.py
@@ -42,7 +42,7 @@ def open_anndata(
         if h5ad.schema_version == "":
             h5ad.schema_version = get_cellxgene_schema_version(ad)
         if h5ad.schema_version not in CXG_SCHEMA_VERSION_IMPORT:
-            logging.error(f"H5AD has old schema version, skipping {h5ad.dataset_h5ad_path}")
+            logging.warning(f"H5AD has old schema version, skipping {h5ad.dataset_h5ad_path}")
             continue
 
         # Multi-organism datasets - any dataset with 2+ feature_reference organisms is ignored,

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/build_soma.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/build_soma.py
@@ -116,7 +116,7 @@ def build_step1_get_source_datasets(args: CensusBuildArgs) -> List[Dataset]:
     datasets = load_manifest(args.config.manifest)
     if len(datasets) == 0:
         logging.error("No H5AD files in the manifest (or we can't find the files)")
-        raise AssertionError("No H5AD files in the manifest (or we can't find the files)")
+        raise RuntimeError("No H5AD files in the manifest (or we can't find the files)")
 
     # Testing/debugging hook - hidden option
     if args.config.test_first_n is not None and args.config.test_first_n > 0:

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/manifest.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/manifest.py
@@ -68,11 +68,13 @@ def load_manifest_from_CxG() -> List[Dataset]:
         assets = dataset.get("assets", [])
         assets_h5ad = [a for a in assets if a["filetype"] == "H5AD"]
         if not assets_h5ad:
-            logging.error(f"Unable to find H5AD asset for dataset id {dataset_id} - ignoring this dataset")
-            continue
+            msg = f"Manifest fetch: unable to find H5AD asset for dataset id {dataset_id} - this should never happen and is likely an upstream bug"
+            logging.error(msg)
+            raise RuntimeError(msg)
         if len(assets_h5ad) > 1:
-            logging.error(f"Dataset id {dataset_id} has more than one H5AD asset - ignoring this dataset")
-            continue
+            msg = f"Manifest fetch: dataset id {dataset_id} has more than one H5AD asset - this should never happen and is likely an upstream bug"
+            logging.error(msg)
+            raise RuntimeError(msg)
         asset_h5ad_uri = assets_h5ad[0]["url"]
         asset_h5ad_filesize = assets_h5ad[0]["filesize"]
 

--- a/tools/cellxgene_census_builder/tests/test_manifest.py
+++ b/tools/cellxgene_census_builder/tests/test_manifest.py
@@ -1,6 +1,8 @@
 import pathlib
 from unittest.mock import patch
 
+import pytest
+
 from cellxgene_census_builder.build_soma.manifest import load_manifest
 
 
@@ -109,7 +111,7 @@ def test_load_manifest_from_cxg_excludes_datasets_with_old_schema() -> None:
 
 def test_load_manifest_from_cxg_excludes_datasets_with_no_assets() -> None:
     """
-    `load_manifest` should exclude datasets that do not have assets
+    `load_manifest` should raise error if it finds datasets without assets
     """
     with patch("cellxgene_census_builder.build_soma.manifest.fetch_json") as m:
         m.return_value = [
@@ -133,7 +135,5 @@ def test_load_manifest_from_cxg_excludes_datasets_with_no_assets() -> None:
             },
         ]
 
-        manifest = load_manifest(None)
-        assert len(manifest) == 1
-        assert manifest[0].dataset_id == "dataset_id_1"
-        assert manifest[0].dataset_asset_h5ad_uri == "https://fake.url/dataset_id_1.h5ad"
+        with pytest.raises(RuntimeError):
+            load_manifest(None)

--- a/tools/cellxgene_census_builder/tests/test_manifest.py
+++ b/tools/cellxgene_census_builder/tests/test_manifest.py
@@ -2,7 +2,6 @@ import pathlib
 from unittest.mock import patch
 
 import pytest
-
 from cellxgene_census_builder.build_soma.manifest import load_manifest
 
 


### PR DESCRIPTION
Fixes #606 

Changes:
* if the response from the upstream curation API is suspect, error out.  Do not silently ignore and move on.
* where we were logging as an Error, but it was really a Warning, change log level
* raise RuntimeError in cases of intentionally "bailing" rather than raising AssertionError (save that for assertions)
* fix unit test to match new (expected) behavior
