### PR TITLE
Complete docstrings for PyTorch ExperimentDataPipe API

### DIFF
--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
@@ -370,7 +370,7 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsAndXDatum]]):  # type: ig
                 through data. Defaults to ``True``.
 
         Returns:
-            ``ExperimentDataPipe``
+            The constructed ``ExperimentDataPipe``.
 
         Lifecycle:
             experimental
@@ -514,10 +514,8 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsAndXDatum]]):  # type: ig
         """
         Get data loading stats for this ``ExperimentDataPipe``.
 
-        Args: None.
-
         Returns:
-            ``Stats`` object.
+            The ``Stats`` object for this ``ExperimentDataPipe``.
 
         Lifecycle:
             experimental
@@ -532,10 +530,8 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsAndXDatum]]):  # type: ig
         (i.e. DataLoader instantiated with num_workers > 0), the obs (cell) count will reflect the size of the
         partition of the data assigned to the active process.
 
-        Args: None.
-
         Returns:
-            2-tuple of ``int``s, for obs and var counts, respectively.
+            A 2-tuple of ``int``s, for obs and var counts, respectively.
 
         Lifecycle:
             experimental
@@ -558,7 +554,7 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsAndXDatum]]):  # type: ig
         See https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.LabelEncoder.html.
 
         Returns:
-            ``Dict[str, LabelEncoder]`` mapping column names to ``LabelEncoder``s.
+            A ``Dict[str, LabelEncoder]``, mapping column names to ``LabelEncoder``s.
         """
         self._init()
         assert self._encoders is not None
@@ -579,8 +575,8 @@ def experiment_dataloader(
 ) -> DataLoader:
     """
     Factory method for PyTorch ``DataLoader``. This method can be used to safely instantiate a
-    ``DataLoader`` that works with the ``ExperimentDataPipe``, since not all of the ``DataLoader`` constructor params
-    can be used (``batch_size``, ``sampler``, ``batch_sampler``, ``collate_fn``).
+    ``DataLoader`` that works with the ``ExperimentDataPipe``, since some of the ``DataLoader`` constructor params
+    are not applicable when using a ``IterDataPipe`` (``batch_size``, ``sampler``, ``batch_sampler``, ``collate_fn``).
 
     Args:
         datapipe:

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
@@ -593,8 +593,7 @@ def experiment_dataloader(
         A ``torch.utils.data.DataLoader``.
 
     Raises:
-        ValueError: if any of the ``batch_size``, ``sampler``, ``batch_sampler``, or ``collate_fn`` params are passed
-        as keyword arguments.
+        ValueError: if any of the ``batch_size``, ``sampler``, ``batch_sampler``, or ``collate_fn`` params are passed as keyword arguments.
 
 
     Lifecycle:

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
@@ -359,7 +359,7 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsAndXDatum]]):  # type: ig
                 rank 2 (multiple rows).
             sparse_X:
                 Controls whether the ``X`` data is returned as a dense or sparse Tensor. As ``X`` data is very sparse,
-                setting this to ``True` will reduce memory usage, if the model supports use of sparse Tensors. Defaults
+                setting this to ``True`` will reduce memory usage, if the model supports use of sparse Tensors. Defaults
                 to ``False``, since sparse Tensors are still experimental in PyTorch.
             soma_buffer_bytes:
                 The number of bytes to use for reading data from SOMA. If not specified, will use the default SOMA

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
@@ -96,7 +96,7 @@ class Stats:
 def _open_experiment(
     uri: str, aws_region: Optional[str] = None, soma_buffer_bytes: Optional[int] = None
 ) -> soma.Experiment:
-    """Internal method for opening a SOMA experiment as a context manager."""
+    """Internal method for opening a SOMA ``Experiment`` as a context manager."""
 
     context = _build_soma_tiledb_context(aws_region)
 
@@ -271,7 +271,7 @@ class _ObsAndXIterator(Iterator[ObsAndXDatum]):
 
 class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsAndXDatum]]):  # type: ignore
     """
-    An iterable-style PyTorch ``DataPipe`` that reads ``obs`` and ``X`` data from a SOMA Experiment, based upon the
+    An iterable-style PyTorch ``DataPipe`` that reads ``obs`` and ``X`` data from a SOMA ``Experiment``, based upon the
     specified queries along the ``obs`` and ``var`` axes. Provides an iterator over these data when the object is
     passed to Python's built-in ``iter`` function:
 
@@ -303,7 +303,7 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsAndXDatum]]):  # type: ig
     columns are encoded as integer values. If needed, these values can be decoded by obtaining the encoder for a
     given ``obs`` column name and calling its ``inverse_transform`` method:
 
-    >>> exp_data_pipe.obs_encoders()["<obs_attr_name>"].inverse_transform(encoded_values)
+    >>> exp_data_pipe.obs_encoders["<obs_attr_name>"].inverse_transform(encoded_values)
 
     Lifecycle:
         experimental
@@ -339,9 +339,9 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsAndXDatum]]):  # type: ig
 
         Args:
             experiment:
-                The SOMA Experiment from which to read data.
+                The SOMA ``Experiment`` from which to read data.
             measurement_name:
-                The name of the SOMA measurement to read. Defaults to "raw".
+                The name of the SOMA ``Measurement`` to read. Defaults to "raw".
             X_name:
                 The name of the X layer to read. Defaults to "X".
             obs_query:
@@ -523,7 +523,7 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsAndXDatum]]):  # type: ig
     @property
     def shape(self) -> Tuple[int, int]:
         """
-        Get the shape of the data that will be returned by this ExperimentDataPipe. This is the number of
+        Get the shape of the data that will be returned by this ``ExperimentDataPipe``. This is the number of
         obs (cell) and var (feature) counts in the returned data. If used in multiprocessing mode
         (i.e. DataLoader instantiated with num_workers > 0), the obs (cell) count will reflect the size of the
         partition of the data assigned to the active process.
@@ -549,7 +549,7 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsAndXDatum]]):  # type: ig
         which were used to encode the ``obs`` column values. These encoders can be used to decode the encoded values as
         follows:
 
-        >>> exp_data_pipe.obs_encoders()["<obs_attr_name>"].inverse_transform(encoded_values)
+        >>> exp_data_pipe.obs_encoders["<obs_attr_name>"].inverse_transform(encoded_values)
 
         See https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.LabelEncoder.html.
 
@@ -591,6 +591,11 @@ def experiment_dataloader(
 
     Returns:
         A ``torch.utils.data.DataLoader``.
+
+    Raises:
+        ValueError: if any of the ``batch_size``, ``sampler``, ``batch_sampler``, or ``collate_fn`` params are passed
+        as keyword arguments.
+
 
     Lifecycle:
         experimental

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
@@ -366,9 +366,10 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsAndXDatum]]):  # type: ig
                 value. Maximum memory utilization is controlled by this parameter, with larger values providing better
                 read performance.
             use_eager_fetch:
-                Controls whether the returned iterator will eagerly fetch data from SOMA while client code is iterating
-                through data. Defaults to ``True``.
-
+                Fetch the next SOMA batch of ``obs`` and ``X`` data immediately after a previously fetched SOMA batch is made
+                available for processing via the iterator. This allows network (or filesystem) requests to be made in
+                parallel with client-side processing of the SOMA data, potentially improving overall performance at the
+                cost of doubling memory utilization. Defaults to ``True``.
         Returns:
             The constructed ``ExperimentDataPipe``.
 

--- a/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
+++ b/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
@@ -274,7 +274,7 @@ def test_sparse_output__non_batched(soma_experiment: Experiment, use_eager_fetch
         measurement_name="RNA",
         X_name="raw",
         obs_column_names=["label"],
-        sparse_X=True,
+        return_sparse_X=True,
         use_eager_fetch=use_eager_fetch,
     )
     batch_iter = iter(exp_data_pipe)
@@ -297,7 +297,7 @@ def test_sparse_output__batched(soma_experiment: Experiment, use_eager_fetch: bo
         X_name="raw",
         obs_column_names=["label"],
         batch_size=3,
-        sparse_X=True,
+        return_sparse_X=True,
         use_eager_fetch=use_eager_fetch,
     )
     batch_iter = iter(exp_data_pipe)

--- a/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
+++ b/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
@@ -20,8 +20,8 @@ try:
 
     from cellxgene_census.experimental.ml.pytorch import (
         ExperimentDataPipe,
-        ObsAndXSOMABatch,
         Stats,
+        _ObsAndXSOMABatch,
         experiment_dataloader,
     )
 except ImportError:
@@ -317,9 +317,9 @@ def test_batching__partial_soma_batches_are_concatenated(soma_experiment: Experi
     with patch("cellxgene_census.experimental.ml.pytorch._ObsAndXSOMAIterator.__next__") as mock_soma_iterator_next:
         # Mock the SOMA batch sizes such that PyTorch batches will span the tail and head of two SOMA batches
         mock_soma_iterator_next.side_effect = [
-            ObsAndXSOMABatch(pd.DataFrame({"soma_joinid": list(range(0, 4))}), sparse.csr_matrix([[1]] * 4), Stats()),
-            ObsAndXSOMABatch(pd.DataFrame({"soma_joinid": list(range(4, 8))}), sparse.csr_matrix([[1]] * 4), Stats()),
-            ObsAndXSOMABatch(pd.DataFrame({"soma_joinid": list(range(8, 10))}), sparse.csr_matrix([[1]] * 2), Stats()),
+            _ObsAndXSOMABatch(pd.DataFrame({"soma_joinid": list(range(0, 4))}), sparse.csr_matrix([[1]] * 4), Stats()),
+            _ObsAndXSOMABatch(pd.DataFrame({"soma_joinid": list(range(4, 8))}), sparse.csr_matrix([[1]] * 4), Stats()),
+            _ObsAndXSOMABatch(pd.DataFrame({"soma_joinid": list(range(8, 10))}), sparse.csr_matrix([[1]] * 2), Stats()),
         ]
 
         exp_data_pipe = ExperimentDataPipe(

--- a/api/python/notebooks/experimental/pytorch.ipynb
+++ b/api/python/notebooks/experimental/pytorch.ipynb
@@ -34,9 +34,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 25,
    "id": "c3dd549f",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-07-10T13:12:17.054514Z",
+     "end_time": "2023-07-10T13:12:19.232463Z"
+    }
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -65,9 +70,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 26,
    "id": "54896e6f",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-07-10T13:12:19.537304Z",
+     "end_time": "2023-07-10T13:12:19.947180Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import cellxgene_census.experimental.ml as census_ml\n",
@@ -115,17 +125,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 27,
    "id": "70a2ddbe",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-07-10T13:12:21.194079Z",
+     "end_time": "2023-07-10T13:12:29.493007Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "(15020, 60664)"
-      ]
+      "text/plain": "(15020, 60664)"
      },
-     "execution_count": 3,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -147,9 +160,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 28,
    "id": "133f594f",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-07-10T13:12:29.493817Z",
+     "end_time": "2023-07-10T13:12:29.494732Z"
+    }
+   },
    "outputs": [],
    "source": [
     "train_datapipe, validation_datapipe, test_datapipe = experiment_datapipe.random_split(\n",
@@ -170,9 +188,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 29,
    "id": "7dfe3c75",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-07-10T13:12:29.497251Z",
+     "end_time": "2023-07-10T13:12:29.498868Z"
+    }
+   },
    "outputs": [],
    "source": [
     "shuffled_train_datapipe = train_datapipe.shuffle()"
@@ -202,9 +225,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 30,
    "id": "39d30df2",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-07-10T13:12:29.510188Z",
+     "end_time": "2023-07-10T13:12:29.513003Z"
+    }
+   },
    "outputs": [],
    "source": [
     "experiment_dataloader = census_ml.experiment_dataloader(shuffled_train_datapipe)"
@@ -232,9 +260,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 31,
    "id": "6b792b4b",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-07-10T13:12:29.515395Z",
+     "end_time": "2023-07-10T13:12:29.523839Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -262,9 +295,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 32,
    "id": "b744cd21",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-07-10T13:12:29.519908Z",
+     "end_time": "2023-07-10T13:12:29.524153Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def train_epoch(model, train_dataloader, loss_fn, optimizer, device):\n",
@@ -277,7 +315,7 @@
     "        optimizer.zero_grad()\n",
     "        X_batch, y_batch = batch\n",
     "\n",
-    "        X_batch = X_batch.to(device)\n",
+    "        X_batch = X_batch.float().to(device)\n",
     "\n",
     "        # Perform prediction\n",
     "        outputs = model(X_batch)\n",
@@ -346,7 +384,7 @@
     "tensor([1, 1, 3, ..., 2, 1, 4])\n",
     "\n",
     "```\n",
-    "Note that cell type values are integer-encoded values, which can be decoded using `experiment_datapipe.obs_encoders()` (more on this below).\n"
+    "Note that cell type values are integer-encoded values, which can be decoded using `experiment_datapipe.obs_encoders` (more on this below).\n"
    ]
   },
   {
@@ -362,19 +400,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 33,
    "id": "733ec2fb",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-07-10T13:12:29.524861Z",
+     "end_time": "2023-07-10T13:15:41.548081Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch 1: Train Loss: 0.1156322 Accuracy 0.4494\n",
-      "Epoch 2: Train Loss: 0.1095988 Accuracy 0.7357\n",
-      "Epoch 3: Train Loss: 0.1089615 Accuracy 0.7300\n",
-      "Epoch 4: Train Loss: 0.1080885 Accuracy 0.7275\n",
-      "Epoch 5: Train Loss: 0.1101440 Accuracy 0.4220\n"
+      "Epoch 1: Train Loss: 0.1156352 Accuracy 0.4472\n",
+      "Epoch 2: Train Loss: 0.1096967 Accuracy 0.7261\n",
+      "Epoch 3: Train Loss: 0.1082206 Accuracy 0.7729\n",
+      "Epoch 4: Train Loss: 0.1071653 Accuracy 0.8268\n",
+      "Epoch 5: Train Loss: 0.1067613 Accuracy 0.8481\n"
      ]
     }
    ],
@@ -389,7 +432,7 @@
     "input_dim = experiment_datapipe.shape[1]\n",
     "\n",
     "# The size of the output dimension is the number of distinct cell_type values\n",
-    "cell_type_encoder = experiment_datapipe.obs_encoders()[\"cell_type\"]\n",
+    "cell_type_encoder = experiment_datapipe.obs_encoders[\"cell_type\"]\n",
     "output_dim = len(cell_type_encoder.classes_)\n",
     "\n",
     "model = LogisticRegression(input_dim, output_dim).to(device)\n",
@@ -414,9 +457,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 34,
    "id": "d3e33edc",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-07-10T13:15:41.549578Z",
+     "end_time": "2023-07-10T13:16:20.570954Z"
+    }
+   },
    "outputs": [],
    "source": [
     "experiment_dataloader = census_ml.experiment_dataloader(test_datapipe)\n",
@@ -435,17 +483,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 35,
    "id": "00e12182",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-07-10T13:16:20.570714Z",
+     "end_time": "2023-07-10T13:16:20.575409Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])"
-      ]
+      "text/plain": "tensor([5, 1, 5, 5, 5, 5, 5, 5, 1, 5, 5, 1, 5, 5, 1, 1])"
      },
-     "execution_count": 11,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -453,7 +504,7 @@
    "source": [
     "model.eval()\n",
     "\n",
-    "outputs = model(X_batch)\n",
+    "outputs = model(X_batch.float())\n",
     "\n",
     "probabilities = torch.nn.functional.softmax(outputs, 1)\n",
     "predictions = torch.argmax(probabilities, axis=1).cpu()\n",
@@ -467,34 +518,33 @@
    "id": "7cb88a5f",
    "metadata": {},
    "source": [
-    "The predictions are returned as the encoded values of `cell_type` label. To recover the original cell type labels as strings, we decode using the `cell_type_encoder`. Here, we obtain the encoder from `experiment_datapipe.obs_encoders()`.\n",
+    "The predictions are returned as the encoded values of `cell_type` label. To recover the original cell type labels as strings, we decode using the encoders from `experiment_datapipe.obs_encoders`.\n",
     "\n",
     "At inference time, if the model inputs are not obtained via an `ExperimentDataPipe`, one could pickle the encoder at training time and save it along with the model. Then, at inference time it can be unpickled and used as shown below."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 36,
    "id": "1cfff865",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-07-10T13:16:20.576538Z",
+     "end_time": "2023-07-10T13:16:20.581020Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "array(['basal cell', 'basal cell', 'basal cell', 'basal cell',\n",
-       "       'basal cell', 'basal cell', 'basal cell', 'basal cell',\n",
-       "       'basal cell', 'basal cell', 'basal cell', 'basal cell',\n",
-       "       'basal cell', 'basal cell', 'basal cell', 'basal cell'],\n",
-       "      dtype=object)"
-      ]
+      "text/plain": "array(['epithelial cell', 'basal cell', 'epithelial cell',\n       'epithelial cell', 'epithelial cell', 'epithelial cell',\n       'epithelial cell', 'epithelial cell', 'basal cell',\n       'epithelial cell', 'epithelial cell', 'basal cell',\n       'epithelial cell', 'epithelial cell', 'basal cell', 'basal cell'],\n      dtype=object)"
      },
-     "execution_count": 12,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "cell_type_encoder = experiment_datapipe.obs_encoders()[\"cell_type\"]\n",
+    "cell_type_encoder = experiment_datapipe.obs_encoders[\"cell_type\"]\n",
     "\n",
     "predicted_cell_types = cell_type_encoder.inverse_transform(predictions)\n",
     "\n",
@@ -512,141 +562,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 37,
    "id": "f4ac8087",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-07-10T13:16:20.744906Z",
+     "end_time": "2023-07-10T13:16:20.746580Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>actual cell type</th>\n",
-       "      <th>predicted cell type</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>epithelial cell</td>\n",
-       "      <td>basal cell</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>epithelial cell</td>\n",
-       "      <td>basal cell</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>epithelial cell</td>\n",
-       "      <td>basal cell</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>epithelial cell</td>\n",
-       "      <td>basal cell</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>epithelial cell</td>\n",
-       "      <td>basal cell</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>epithelial cell</td>\n",
-       "      <td>basal cell</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>epithelial cell</td>\n",
-       "      <td>basal cell</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>epithelial cell</td>\n",
-       "      <td>basal cell</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>epithelial cell</td>\n",
-       "      <td>basal cell</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>epithelial cell</td>\n",
-       "      <td>basal cell</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>epithelial cell</td>\n",
-       "      <td>basal cell</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11</th>\n",
-       "      <td>epithelial cell</td>\n",
-       "      <td>basal cell</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>epithelial cell</td>\n",
-       "      <td>basal cell</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13</th>\n",
-       "      <td>epithelial cell</td>\n",
-       "      <td>basal cell</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>14</th>\n",
-       "      <td>epithelial cell</td>\n",
-       "      <td>basal cell</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>epithelial cell</td>\n",
-       "      <td>basal cell</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   actual cell type predicted cell type\n",
-       "0   epithelial cell          basal cell\n",
-       "1   epithelial cell          basal cell\n",
-       "2   epithelial cell          basal cell\n",
-       "3   epithelial cell          basal cell\n",
-       "4   epithelial cell          basal cell\n",
-       "5   epithelial cell          basal cell\n",
-       "6   epithelial cell          basal cell\n",
-       "7   epithelial cell          basal cell\n",
-       "8   epithelial cell          basal cell\n",
-       "9   epithelial cell          basal cell\n",
-       "10  epithelial cell          basal cell\n",
-       "11  epithelial cell          basal cell\n",
-       "12  epithelial cell          basal cell\n",
-       "13  epithelial cell          basal cell\n",
-       "14  epithelial cell          basal cell\n",
-       "15  epithelial cell          basal cell"
-      ]
+      "text/plain": "   actual cell type predicted cell type\n0   epithelial cell     epithelial cell\n1   epithelial cell          basal cell\n2   epithelial cell     epithelial cell\n3   epithelial cell     epithelial cell\n4   epithelial cell     epithelial cell\n5   epithelial cell     epithelial cell\n6   epithelial cell     epithelial cell\n7   epithelial cell     epithelial cell\n8   epithelial cell          basal cell\n9   epithelial cell     epithelial cell\n10  epithelial cell     epithelial cell\n11  epithelial cell          basal cell\n12  epithelial cell     epithelial cell\n13  epithelial cell     epithelial cell\n14  epithelial cell          basal cell\n15  epithelial cell          basal cell",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>actual cell type</th>\n      <th>predicted cell type</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>epithelial cell</td>\n      <td>epithelial cell</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>epithelial cell</td>\n      <td>basal cell</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>epithelial cell</td>\n      <td>epithelial cell</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>epithelial cell</td>\n      <td>epithelial cell</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>epithelial cell</td>\n      <td>epithelial cell</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>epithelial cell</td>\n      <td>epithelial cell</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>epithelial cell</td>\n      <td>epithelial cell</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>epithelial cell</td>\n      <td>epithelial cell</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>epithelial cell</td>\n      <td>basal cell</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>epithelial cell</td>\n      <td>epithelial cell</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>epithelial cell</td>\n      <td>epithelial cell</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>epithelial cell</td>\n      <td>basal cell</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>epithelial cell</td>\n      <td>epithelial cell</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>epithelial cell</td>\n      <td>epithelial cell</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>epithelial cell</td>\n      <td>basal cell</td>\n    </tr>\n    <tr>\n      <th>15</th>\n      <td>epithelial cell</td>\n      <td>basal cell</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
-     "execution_count": 13,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -668,7 +598,7 @@
    "id": "c2fd35fa",
    "metadata": {},
    "source": [
-    "As we can see, the predictions are poor. It is as left as an excercise to the reader to find a better performing model."
+    "As we can see, the predictions are poor. It is as left as an exercise to the reader to find a better performing model."
    ]
   }
  ],

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,16 @@ The documentation site is rebuilt each time a tag is created on the repo, which 
 
 A full rebuild can also be triggered manually as the workflow supports `workflow_dispatch`. This should be done if a bug in the documentation is found and a release is not necessary.
 
-In order to test docsite changes locally, one can run the following command:
+In order to test docsite changes locally, first install the necessary requirements:
+
+```
+pip install -r docs/requirements.txt
+brew install pandoc # Mac OS
+```
+
+Then,
+
+And then run the following command:
 
 ```
 cd docs


### PR DESCRIPTION
Resolves #500
Introduces #614 :)

* Fleshes out docstrings for ExperimentDataPipe et. al.
* Fixes & re-runs pytorch notebook
* Removes testing-only `__main__` from `pytorch.py`
* Rename `{,_}ObsAndXSOMABatch` to indicate it's private
