### PR TITLE
hard error if the builder receives an unsupported CXG schema version

### DIFF
--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/anndata.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/anndata.py
@@ -42,8 +42,9 @@ def open_anndata(
         if h5ad.schema_version == "":
             h5ad.schema_version = get_cellxgene_schema_version(ad)
         if h5ad.schema_version not in CXG_SCHEMA_VERSION_IMPORT:
-            logging.warning(f"H5AD has old schema version, skipping {h5ad.dataset_h5ad_path}")
-            continue
+            msg = f"H5AD has unsupported schema version {h5ad.dataset_h5ad_path}, expected {CXG_SCHEMA_VERSION}"
+            logging.error(msg)
+            raise RuntimeError(msg)
 
         # Multi-organism datasets - any dataset with 2+ feature_reference organisms is ignored,
         # exclusive of values in FEATURE_REFERENCE_IGNORE. See also, cell filter for mismatched

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/anndata.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/anndata.py
@@ -42,7 +42,7 @@ def open_anndata(
         if h5ad.schema_version == "":
             h5ad.schema_version = get_cellxgene_schema_version(ad)
         if h5ad.schema_version not in CXG_SCHEMA_VERSION_IMPORT:
-            msg = f"H5AD has unsupported schema version {h5ad.dataset_h5ad_path}, expected {CXG_SCHEMA_VERSION}"
+            msg = f"H5AD {h5ad.dataset_h5ad_path} has unsupported schema version {h5ad.schema_version}, expected {CXG_SCHEMA_VERSION}"
             logging.error(msg)
             raise RuntimeError(msg)
 

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/manifest.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/manifest.py
@@ -62,7 +62,7 @@ def load_manifest_from_CxG() -> List[Dataset]:
         schema_version = dataset["schema_version"]
 
         if schema_version not in CXG_SCHEMA_VERSION_IMPORT:
-            msg = f"Dropping dataset {dataset_id} due to unsupported schema version"
+            msg = f"Manifest fetch: dataset {dataset_id} contains unsupported schema version {schema_version}."
             logging.error(msg)
             raise RuntimeError(msg)
 

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/manifest.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/manifest.py
@@ -62,8 +62,9 @@ def load_manifest_from_CxG() -> List[Dataset]:
         schema_version = dataset["schema_version"]
 
         if schema_version not in CXG_SCHEMA_VERSION_IMPORT:
-            logging.warning(f"Dropping dataset {dataset_id} due to unsupported schema version")
-            continue
+            msg = f"Dropping dataset {dataset_id} due to unsupported schema version"
+            logging.error(msg)
+            raise RuntimeError(msg)
 
         assets = dataset.get("assets", [])
         assets_h5ad = [a for a in assets if a["filetype"] == "H5AD"]

--- a/tools/cellxgene_census_builder/tests/anndata/test_anndata.py
+++ b/tools/cellxgene_census_builder/tests/anndata/test_anndata.py
@@ -2,6 +2,7 @@ from typing import List
 
 import anndata as ad
 import numpy as np
+import pytest
 from cellxgene_census_builder.build_soma.anndata import (
     get_cellxgene_schema_version,
     make_anndata_cell_filter,
@@ -45,8 +46,8 @@ def test_open_anndata_filters_out_wrong_schema_version_datasets(
     """
     Datasets with a schema version different from `CXG_SCHEMA_VERSION` will not be included by `open_anndata`
     """
-    result = list(open_anndata(".", datasets_with_incorrect_schema_version))
-    assert len(result) == 0
+    with pytest.raises(RuntimeError, match="unsupported schema version"):
+        _ = list(open_anndata(".", datasets_with_incorrect_schema_version))
 
 
 def test_open_anndata_equalizes_raw_and_normalized(datasets_with_larger_raw_layer: List[Dataset]) -> None:

--- a/tools/cellxgene_census_builder/tests/test_manifest.py
+++ b/tools/cellxgene_census_builder/tests/test_manifest.py
@@ -51,8 +51,16 @@ def test_load_manifest_from_cxg() -> None:
                 "title": "dataset #1",
                 "schema_version": "3.0.0",
                 "assets": [
-                    {"filesize": 123, "filetype": "H5AD", "url": "https://fake.url/dataset_id_1.h5ad"},
-                    {"filesize": 234, "filetype": "RDS", "url": "https://fake.url/dataset_id_1.rds"},
+                    {
+                        "filesize": 123,
+                        "filetype": "H5AD",
+                        "url": "https://fake.url/dataset_id_1.h5ad",
+                    },
+                    {
+                        "filesize": 234,
+                        "filetype": "RDS",
+                        "url": "https://fake.url/dataset_id_1.rds",
+                    },
                 ],
             },
             {
@@ -62,7 +70,13 @@ def test_load_manifest_from_cxg() -> None:
                 "collection_doi": None,
                 "title": "dataset #2",
                 "schema_version": "3.0.0",
-                "assets": [{"filesize": 456, "filetype": "H5AD", "url": "https://fake.url/dataset_id_2.h5ad"}],
+                "assets": [
+                    {
+                        "filesize": 456,
+                        "filetype": "H5AD",
+                        "url": "https://fake.url/dataset_id_2.h5ad",
+                    }
+                ],
             },
         ]
 
@@ -76,7 +90,7 @@ def test_load_manifest_from_cxg() -> None:
         assert manifest[1].asset_h5ad_filesize == 456
 
 
-def test_load_manifest_from_cxg_excludes_datasets_with_old_schema() -> None:
+def test_load_manifest_from_cxg_errors_on_datasets_with_old_schema() -> None:
     """
     `load_manifest` should exclude datasets that do not have a current schema version.
     """
@@ -89,7 +103,13 @@ def test_load_manifest_from_cxg_excludes_datasets_with_old_schema() -> None:
                 "collection_doi": None,
                 "title": "dataset #1",
                 "schema_version": "3.0.0",
-                "assets": [{"filesize": 123, "filetype": "H5AD", "url": "https://fake.url/dataset_id_1.h5ad"}],
+                "assets": [
+                    {
+                        "filesize": 123,
+                        "filetype": "H5AD",
+                        "url": "https://fake.url/dataset_id_1.h5ad",
+                    }
+                ],
             },
             {
                 "dataset_id": "dataset_id_2",
@@ -98,14 +118,18 @@ def test_load_manifest_from_cxg_excludes_datasets_with_old_schema() -> None:
                 "collection_doi": None,
                 "title": "dataset #2",
                 "schema_version": "2.0.0",  # Old schema version
-                "assets": [{"filesize": 456, "filetype": "H5AD", "url": "https://fake.url/dataset_id_2.h5ad"}],
+                "assets": [
+                    {
+                        "filesize": 456,
+                        "filetype": "H5AD",
+                        "url": "https://fake.url/dataset_id_2.h5ad",
+                    }
+                ],
             },
         ]
 
-        manifest = load_manifest(None)
-        assert len(manifest) == 1
-        assert manifest[0].dataset_id == "dataset_id_1"
-        assert manifest[0].dataset_asset_h5ad_uri == "https://fake.url/dataset_id_1.h5ad"
+        with pytest.raises(RuntimeError, match=r"unsupported schema version"):
+            load_manifest(None)
 
 
 def test_load_manifest_from_cxg_excludes_datasets_with_no_assets() -> None:
@@ -121,7 +145,13 @@ def test_load_manifest_from_cxg_excludes_datasets_with_no_assets() -> None:
                 "collection_doi": None,
                 "title": "dataset #1",
                 "schema_version": "3.0.0",
-                "assets": [{"filesize": 123, "filetype": "H5AD", "url": "https://fake.url/dataset_id_1.h5ad"}],
+                "assets": [
+                    {
+                        "filesize": 123,
+                        "filetype": "H5AD",
+                        "url": "https://fake.url/dataset_id_1.h5ad",
+                    }
+                ],
             },
             {
                 "dataset_id": "dataset_id_2",


### PR DESCRIPTION
This PR tightens up error detection for a "should never happen" case where we receive an unsupported CxG schema version in an H5AD file.  The previous behavior was to log a warning and drop the dataset.  The new behavior is to fail the build.

There are no cases of such warning in the logs for the past few weekly builds, and our process is such that it should not occur. This is just an additional sanity check.
