### PR TITLE
add do_not_delete flag to release.json format

### DIFF
--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/__main__.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/__main__.py
@@ -178,6 +178,7 @@ def do_the_release(args: CensusBuildArgs) -> bool:
             "uri": urlcat(args.config.cellxgene_census_S3_path, args.build_tag, "h5ads/"),
             "s3_region": "us-west-2",
         },
+        "do_not_delete": False,
     }
     make_a_release(
         args.config.cellxgene_census_S3_path, args.build_tag, release, make_latest=True, dryrun=args.config.dryrun

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/release_cleanup.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/release_cleanup.py
@@ -94,9 +94,9 @@ def _find_removal_candidates(release_manifest: CensusReleaseManifest, days_older
     # In practice, we REQUIRE at least a `latest` tag, so this list should never be empty
     assert len(is_aliased) > 0
 
-    candidates = []
+    candidates: List[CensusVersionName] = []
     for rls_tag, rls_info in release_manifest.items():
-        if isinstance(rls_info, dict) and rls_tag not in is_aliased:
+        if isinstance(rls_info, dict) and (rls_tag not in is_aliased) and not rls_info.get("do_not_delete", False):
             # candidate for deletion - check timestamp
             rls_build_date = datetime.fromisoformat(rls_info["release_build"])
             if rls_build_date < delete_before_date:

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/release_manifest.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/release_manifest.py
@@ -28,6 +28,7 @@ CensusVersionDescription = TypedDict(
         "release_build": str,  # date of build
         "soma": CensusLocator,  # SOMA objects locator
         "h5ads": CensusLocator,  # source H5ADs locator
+        "do_not_delete": Optional[bool],  # if set, prevents automated deletion
     },
 )
 CensusReleaseManifest = Dict[CensusVersionName, Union[CensusVersionName, CensusVersionDescription]]

--- a/tools/cellxgene_census_builder/tests/test_release_cleanup.py
+++ b/tools/cellxgene_census_builder/tests/test_release_cleanup.py
@@ -14,6 +14,8 @@ def tag_days_old(days_old: int) -> str:
 TAG_NOW = tag_days_old(0)
 TAG_10D_OLD = tag_days_old(10)
 TAG_100D_OLD = tag_days_old(100)
+TAG_LTS_A = tag_days_old(1000)
+TAG_LTS_B = tag_days_old(1001)
 
 S3_PREFIX = "s3://bucket/path/"
 
@@ -33,6 +35,18 @@ RELEASE_MANIFEST: CensusReleaseManifest = {
         "release_build": TAG_100D_OLD,
         "soma": {"uri": f"{S3_PREFIX}{TAG_100D_OLD}/soma/", "s3_region": "us-west-2"},
         "h5ads": {"uri": f"{S3_PREFIX}{TAG_100D_OLD}/h5ads/", "s3_region": "us-west-2"},
+    },
+    "stable": TAG_LTS_A,
+    TAG_LTS_A: {  # mock LTS release with an alias, but without a do_not_delete flag
+        "release_build": TAG_LTS_A,
+        "soma": {"uri": f"{S3_PREFIX}{TAG_LTS_A}/soma/", "s3_region": "us-west-2"},
+        "h5ads": {"uri": f"{S3_PREFIX}{TAG_LTS_A}/h5ads/", "s3_region": "us-west-2"},
+    },
+    TAG_LTS_B: {  # mock LTS release lacking an alias, but with a do_not_delete flag
+        "release_build": TAG_LTS_B,
+        "soma": {"uri": f"{S3_PREFIX}{TAG_LTS_B}/soma/", "s3_region": "us-west-2"},
+        "h5ads": {"uri": f"{S3_PREFIX}{TAG_LTS_B}/h5ads/", "s3_region": "us-west-2"},
+        "do_not_delete": True,
     },
 }
 

--- a/tools/cellxgene_census_builder/tests/test_release_manifest.py
+++ b/tools/cellxgene_census_builder/tests/test_release_manifest.py
@@ -57,6 +57,7 @@ def h5ads_locator(tag: CensusVersionName) -> CensusLocator:
                 "release_build": "2022-01-10",
                 "soma": soma_locator("2022-01-10"),
                 "h5ads": h5ads_locator("2022-01-10"),
+                "do_not_delete": False,
             },
         },
         {
@@ -68,6 +69,7 @@ def h5ads_locator(tag: CensusVersionName) -> CensusLocator:
                         "release_build": tag,
                         "soma": soma_locator(tag),
                         "h5ads": h5ads_locator(tag),
+                        "do_not_delete": False,
                     },
                 )
                 for tag in ["2022-01-10", "2023-09-12"]

--- a/tools/cellxgene_census_builder/tests/test_workflow_steps.py
+++ b/tools/cellxgene_census_builder/tests/test_workflow_steps.py
@@ -87,6 +87,7 @@ def test_do_the_release(tmp_path: pathlib.Path, dryrun: bool) -> None:
         "release_date": None,
         "soma": {"uri": f"{TEST_BUCKET_PATH}/{build_tag}/soma/", "s3_region": "us-west-2"},
         "h5ads": {"uri": f"{TEST_BUCKET_PATH}/{build_tag}/h5ads/", "s3_region": "us-west-2"},
+        "do_not_delete": False,
     }
     assert make_a_release_patch.call_count == 1
     assert make_a_release_patch.call_args == (


### PR DESCRIPTION
Related to #242 

Adds a new flag to the release.json format:  `do_not_delete`.  If set to a true-ish value, will prevent the automated build process from garbage collecting a build.  This is intended for use in protecting LTS releases (when the LTS is tagged, this flag should be set on the build).

If the flag is not set, or is false-ish, the build will be subject to the standard test build cleanup.
