### PR TITLE
fix: dialog

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -169,6 +169,14 @@ html.writer-html4 .rst-content dl:not(.docutils)>dt:before,html.writer-html5 .rs
     max-width: 400px!important;
     max-height: 266px!important;
     padding: 24px;
+
+}
+
+/*
+ * We should only add `display: flex` to open state, otherwise it will be shown
+ * as a flexbox even when it's closed.
+ */
+#newsletter-modal[open] {
     display: flex;
     flex-direction: column;
     justify-content: space-between;

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -260,7 +260,7 @@
       <div id="newsletter-content">
         <div id="newsletter-callout">Join Our Newsletter</div>
         <div id="newsletter-description">Get a quarterly email with the latest CELLxGENE features and data.</div>
-        <!-- Hubspot Form target -->
+        <!-- HubSpot Form target -->
         <div id="newsletter-form-container"></div>
       </div>
 
@@ -268,12 +268,6 @@
     </dialog>
   </div>
   {% include "versions.html" %}
-
-  <script type="text/javascript">
-      jQuery(function () {
-          SphinxRtdTheme.Navigation.enable({{ 'true' if theme_sticky_navigation|tobool else 'false' }});
-      });
-  </script>
 
   <script>
     var script = document.createElement('script');


### PR DESCRIPTION
Turned out that we can't just use `display: flex` on the `<dialog />`, otherwise it conflicts with `display: none;` and thus showing the dialog when it's supposed to be hidden!

https://github.com/chanzuckerberg/cellxgene-census/assets/6309723/7581d2a5-0819-43dc-8c55-1bfa8a321749

