### PR TITLE
[NO MERGE] observation_joinid

### DIFF
--- a/docs/cellxgene_census_schema.md
+++ b/docs/cellxgene_census_schema.md
@@ -1,8 +1,8 @@
 # CZ CELLxGENE Discover Census Schema 
 
-**Version**: 1.1.0
+**Version**: 1.2.0
 
-**Last edited**: July, 2023.
+**Last edited**: August, 2023.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED" "MAY", and "OPTIONAL" in this document are to be interpreted as described in [BCP 14](https://tools.ietf.org/html/bcp14), [RFC2119](https://www.rfc-editor.org/rfc/rfc2119.txt), and [RFC8174](https://www.rfc-editor.org/rfc/rfc8174.txt) when, and only when, they appear in all capitals, as shown here.
 
@@ -881,11 +881,19 @@ Cell metadata MUST be encoded as a `SOMADataFrame` with the following columns:
     <td>float32</td>
     <td>For this observation, the variance of the `X['raw']` counts (raw) matrix values. Zeroes are excluded from the calculation.</td>
   </tr>
+  <tr>
+    <td>observation_joinid</td>
+    <td>string</td>
+    <td>A short string which uniquely identifies the cell *within* its source dataset. This ID does not guarantee global uniqueness.</td>
+  </tr>
 </tbody>
 </table>
 
 
 ## Changelog
+
+### Version 1.2.0
+* Add `observation_joinid` to `obs` dataframe
 
 ### Version 1.1.0
 * Adds `dataset_version_id` to "Census table of CELLxGENE Discover datasets – `census_obj["census_info"]["datasets"]`"

--- a/docs/cellxgene_census_schema.md
+++ b/docs/cellxgene_census_schema.md
@@ -884,7 +884,7 @@ Cell metadata MUST be encoded as a `SOMADataFrame` with the following columns:
   <tr>
     <td>observation_joinid</td>
     <td>string</td>
-    <td>A short string which uniquely identifies the observation <b>within</b> its source dataset. This ID does not guarantee global uniqueness, nor is the ID value guaranteed to remain constant across releases of the Census.</td>
+    <td>A string value which uniquely identifies the observation <b>within</b> its source dataset. This ID does not guarantee global uniqueness, nor is the ID value guaranteed to remain constant across releases of the Census.</td>
   </tr>
 </tbody>
 </table>

--- a/docs/cellxgene_census_schema.md
+++ b/docs/cellxgene_census_schema.md
@@ -1,10 +1,6 @@
 # CZ CELLxGENE Discover Census Schema 
 
-<<<<<<< HEAD
 **Version**: 1.1.0
-=======
-**Version**: 1.1.0.
->>>>>>> main
 
 **Last edited**: July, 2023.
 

--- a/docs/cellxgene_census_schema.md
+++ b/docs/cellxgene_census_schema.md
@@ -884,7 +884,7 @@ Cell metadata MUST be encoded as a `SOMADataFrame` with the following columns:
   <tr>
     <td>observation_joinid</td>
     <td>string</td>
-    <td>A short string which uniquely identifies the cell *within* its source dataset. This ID does not guarantee global uniqueness.</td>
+    <td>A short string which uniquely identifies the observation <b>within</b> its source dataset. This ID does not guarantee global uniqueness, nor is the ID value guaranteed to remain constant across releases of the Census.</td>
   </tr>
 </tbody>
 </table>

--- a/tools/cellxgene_census_builder/pyproject.toml
+++ b/tools/cellxgene_census_builder/pyproject.toml
@@ -47,6 +47,7 @@ dependencies= [
     "psutil==5.9.5",
     "pyyaml==6.0",
     "numba==0.56.4",
+    "xxhash==3.2.0",
 ]
 
 [project.urls]

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/experiment_builder.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/experiment_builder.py
@@ -233,7 +233,7 @@ class ExperimentBuilder:
             obs_df.index.to_series()
             .map(xxh3_64_intdigest)
             .astype(np.uint64)
-            .apply(lambda v: b85encode(v.to_bytes(8, "big")))
+            .apply(lambda v: b85encode(v.to_bytes(8, "big")).decode("ascii"))
         )
         obs_df = obs_df.reset_index(drop=True)
         obs_df["soma_joinid"] = range(self.n_obs, self.n_obs + len(obs_df))

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/validate_soma.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/validate_soma.py
@@ -184,6 +184,7 @@ def _validate_axis_dataframes(args: Tuple[str, str, Dataset, List[ExperimentSpec
                         "tissue_general",
                         "tissue_general_ontology_term_id",
                         *CENSUS_OBS_STATS_COLUMNS,
+                        "observation_joinid",
                     ]
                 )
                 .sort_values(by="soma_joinid")


### PR DESCRIPTION
Add `observation_joinid` to the `obs` dataframe for all experiments.

Changes:
* add field definition to the Census schema and bump schema version to 1.2.0
* add hash-based implementation based upon AnnData index value

Fixes: #611 
Fixes: #610 

Example:
```
In [1]: census['census_data']['homo_sapiens'].obs.schema
Out[1]: 
soma_joinid: int64
dataset_id: large_string
assay: large_string
assay_ontology_term_id: large_string
cell_type: large_string
cell_type_ontology_term_id: large_string
development_stage: large_string
development_stage_ontology_term_id: large_string
disease: large_string
disease_ontology_term_id: large_string
donor_id: large_string
is_primary_data: bool
self_reported_ethnicity: large_string
self_reported_ethnicity_ontology_term_id: large_string
sex: large_string
sex_ontology_term_id: large_string
suspension_type: large_string
tissue: large_string
tissue_ontology_term_id: large_string
tissue_general: large_string
tissue_general_ontology_term_id: large_string
raw_sum: float
nnz: int64
raw_mean_nnz: float
raw_variance_nnz: float
n_measured_vars: int64
observation_joinid: large_string

In [2]: census['census_data']['homo_sapiens'].obs.read().concat().to_pandas().observation_joinid
Out[2]: 
0         d(%tKmdY|z
1         WDk4APgw8K
2         vEU-iEog~7
3         Nrdu{h>B$I
4         ?Xz^k-h=Xa
             ...    
490680    J-KWDC*+ER
490681    9IQWJS$=UW
490682    d>_HjoBf{L
490683    >`S5%*!kAu
490684    4`5=Xso}MA
Name: observation_joinid, Length: 490685, dtype: object
```