### PR TITLE
implement worker count limit

### DIFF
--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/__main__.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/__main__.py
@@ -43,6 +43,12 @@ def create_args_parser() -> argparse.ArgumentParser:
         help="Use multiple processes",
     )
     parser.add_argument(
+        "--max_worker_processes",
+        type=int,
+        default=CENSUS_CONFIG_DEFAULTS["max_worker_processes"],
+        help="Limit on number of worker processes",
+    )
+    parser.add_argument(
         "--build-tag",
         type=str,
         default=datetime.now().astimezone().date().isoformat(),

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_state.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_state.py
@@ -37,9 +37,19 @@ CENSUS_CONFIG_DEFAULTS = {
     #
     # Default mode is multi-process.
     "multi_process": True,
+    #
     # The memory budget used to determine appropriate parallelism in many steps of build.
     # Only set to a smaller number if you want to not use all available RAM.
     "memory_budget": int(psutil.virtual_memory().total),
+    #
+    # 'max_worker_processes' sets a limit on the number of worker processes. On high-CPU boxes,
+    # this limit is needed to avoid exceeding the VM map kernel limit (vm.max_map_count). On Ubuntu 22.04,
+    # the default value is 65536. This kernel limitation becomes an issue due to excess thread allocation
+    # by TileDB-SOMA: https://github.com/single-cell-data/TileDB-SOMA/issues/1550. Currently, the per-process
+    # TileDB context allocates approximately 650 threads (and VM maps) per worker process, as currently
+    # utilized by the Census builder. This hard-cap can be increased when this issue is resolved.
+    # 96 * 650 == 62400, which is < 65536.
+    "max_worker_processes": 96,
     #
     # Host minimum resource validation
     "host_validation_disable": False,  # if True, host validation checks will be skipped


### PR DESCRIPTION
Constrain worker process parallelism on high-CPU count hosts, to work around single-cell-data/TileDB-SOMA#1550.  See #672 for details of how this failure manifests.  When single-cell-data/TileDB-SOMA#1550 is resolved, this limit can be raised (but it should not be removed).

Fixes #672

Note to reviewers: a hard limit was implemented rather than simply reconfiguring the kernel param (`vm.max_map_count`) because it is impractical to change this param from inside a Docker container.