### PR TITLE
[r] move SingleCellExperiment from Imports to Suggests

### DIFF
--- a/api/r/cellxgene.census/DESCRIPTION
+++ b/api/r/cellxgene.census/DESCRIPTION
@@ -22,7 +22,6 @@ Imports:
   jsonlite,
   methods,
   Seurat (>= 4.1.0),
-  SingleCellExperiment (>= 1.20.0),
   stats,
   tiledbsoma,
   tiledb
@@ -30,6 +29,7 @@ Suggests:
   bit64,
   knitr,
   rmarkdown,
+  SingleCellExperiment (>= 1.20.0),
   testthat (>= 3.0.0),
   withr
 Config/testthat/edition: 3

--- a/api/r/cellxgene.census/DESCRIPTION
+++ b/api/r/cellxgene.census/DESCRIPTION
@@ -14,6 +14,7 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Additional_repositories: https://tiledb-inc.r-universe.dev
+Remotes: bioc::release/SingleCellExperiment
 biocViews:
 Imports:
   aws.s3,

--- a/api/r/cellxgene.census/DESCRIPTION
+++ b/api/r/cellxgene.census/DESCRIPTION
@@ -14,7 +14,6 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Additional_repositories: https://tiledb-inc.r-universe.dev
-Remotes: bioc::release/SingleCellExperiment
 biocViews:
 Imports:
   aws.s3,


### PR DESCRIPTION
The dependency on SingleCellExperiment is tricky because it's sourced from bioconductor, not CRAN nor r-universe. The fresh install instructions fail unless additional steps are taken to install it from bioconductor. 

Move it from our DESCRIPTION's Imports to Suggests, which [follows tiledbsoma](https://github.com/single-cell-data/TileDB-SOMA/blob/a103172aeabb57ae0865d52e6107326e4e5b4878/apis/r/DESCRIPTION#L69).

Right now just seeing if we still pass CI.