### PR TITLE
[docs] add explicit filtering for None git tags

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,8 @@ author = 'Chan Zuckerberg Initiative'
 
 import git
 repo = git.Repo(search_parent_directories=True)
-tags = sorted(repo.tags, key=lambda t: t.tag.tagged_date)
+tags = [t for t in repo.tags if t.tag is not None]
+tags = sorted(tags, key=lambda t: t.tag.tagged_date)
 latest_tag = tags[-1]
 
 version = str(latest_tag)


### PR DESCRIPTION
Tentatively fixes #711 

I am not sure why the `tag` object is sometimes None, but this should fix it. The issue isn't easily reproducible since tags are global and the current state of the git repo doesn't present this issue.