### PR TITLE
Explicit log message tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         args: [ "--config=./tools/pyproject.toml", "--fix" ]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: mypy
         name: mypy-cellxgene-census

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/pp/_stats.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/pp/_stats.py
@@ -73,7 +73,7 @@ def mean_variance(
     def iterate() -> Generator[Tuple[npt.NDArray[np.int64], Any], None, None]:
         with futures.ThreadPoolExecutor(max_workers=1) as pool:  # Note: _EagerIterator only supports one thread
             for arrow_tbl in _EagerIterator(query.X(layer).tables(), pool=pool):
-                dim = idx.get_indexer(arrow_tbl[f"soma_dim_{1-axis}"].to_numpy())  # type: ignore[no-untyped-call]
+                dim = idx.get_indexer(arrow_tbl[f"soma_dim_{1-axis}"].to_numpy())
                 data = arrow_tbl["soma_data"].to_numpy()
                 yield dim, data
 

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/util/_csr_iter.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/util/_csr_iter.py
@@ -100,7 +100,7 @@ def X_sparse_iter(
             (obs_coords_chunk, var_coords),
             (
                 tbl["soma_data"].to_numpy(),
-                pd.Index(obs_coords_chunk).get_indexer(tbl["soma_dim_0"].to_numpy()),  # type: ignore[no-untyped-call]
+                pd.Index(obs_coords_chunk).get_indexer(tbl["soma_dim_0"].to_numpy()),
                 query.indexer.by_var(tbl["soma_dim_1"].to_numpy()),
             ),
         )

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/validate_soma.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/validate_soma.py
@@ -418,7 +418,7 @@ def _validate_Xraw_contents_by_dataset(args: Tuple[str, str, Dataset, List[Exper
 
                 # positionally re-index
                 cols_by_position = var_index.get_indexer(X_raw_var_joinids)
-                rows_by_position = pd.Index(obs_joinids_split).get_indexer(X_raw_obs_joinids)  # type: ignore[no-untyped-call]
+                rows_by_position = pd.Index(obs_joinids_split).get_indexer(X_raw_obs_joinids)
                 del X_raw_obs_joinids
 
                 # Check that raw_sum stat matches raw layer

--- a/tools/cellxgene_census_builder/tests/test_release_manifest.py
+++ b/tools/cellxgene_census_builder/tests/test_release_manifest.py
@@ -21,6 +21,7 @@ from .conftest import has_aws_credentials
 TEST_CENSUS_BASE_URL = "s3://bucket/path/"
 
 
+@pytest.mark.xfail(reason="Waiting on PR #552 (mirrors)")
 @pytest.mark.live_corpus
 def test_get_release_manifest() -> None:
     census_base_url = CENSUS_CONFIG_DEFAULTS["cellxgene_census_S3_path"]
@@ -48,6 +49,7 @@ def h5ads_locator(tag: CensusVersionName) -> CensusLocator:
     return {"uri": f"{TEST_CENSUS_BASE_URL}{tag}/h5ads/", "s3_region": CENSUS_AWS_REGION}
 
 
+@pytest.mark.xfail(reason="Waiting on PR #552 (mirrors)")
 @pytest.mark.parametrize(
     "release_manifest",
     [
@@ -136,6 +138,7 @@ def test_validate_release_manifest_errors(
         validate_release_manifest(TEST_CENSUS_BASE_URL, release_manifest, live_corpus_check=False)
 
 
+@pytest.mark.xfail(reason="Waiting on PR #552 (mirrors)")
 @pytest.mark.parametrize(
     "release_manifest,rls_tag,rls_info,make_latest,expected_new_manifest",
     [


### PR DESCRIPTION
Fixes #599 

Builder code logs ERROR messages in some cases, which pytest dutifully records.  There does not appear to be a way of suppressing the reporting of specific, expected, log messages, so I have added explicit tests for them, to acknowledge that we expect them.

Also resolved: 
* updated mypy to latest version
* remove a few typing hints which are no longer necessary

Note to reviewer (CC @ebezzi) - due to changes to the live release.json, motivated by #552, the Builder unit tests are broken.  I have added xfails where needed, and @ebezzi will resolve these issues in his PR.
