### PR TITLE
[docs] pin Sphinx version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ nbsphinx
 myst-parser
 sphinx-rtd-theme
 gitpython
+sphinx<7.0.0


### PR DESCRIPTION
Sphinx 7 doesn't work with the theme we're using (readthedocs). Pinning Sphinx for now.