### PR TITLE
Resolve CI failure caused by X count matrix with zero-sum rows

### DIFF
--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/anndata.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/anndata.py
@@ -156,6 +156,7 @@ def make_anndata_cell_filter(filter_spec: AnnDataFilterSpec) -> AnnDataFilterFun
             X is None or isinstance(X, np.ndarray) or X.has_canonical_format
         ), "Found H5AD with non-canonical X matrix"
 
+        assert X is None or np.all(X.sum(axis=1) > 0), "H5AD contains a cell with no X values > 0"
         return ad
 
     return _filter

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/stats.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/stats.py
@@ -19,7 +19,9 @@ def get_obs_stats(
 
     raw_sum = raw_X.sum(axis=1, dtype=np.float64).A1
     nnz = raw_X.getnnz(axis=1)
-    raw_mean_nnz = raw_sum / nnz
+    with np.errstate(divide="ignore"):
+        raw_mean_nnz = raw_sum / nnz
+    raw_mean_nnz[~np.isfinite(raw_mean_nnz)] = 0.0
     raw_variance_nnz = _var(raw_X, axis=1, ddof=1)
     n_measured_vars = np.full((raw_X.shape[0],), (raw_X.sum(axis=0, dtype=np.float64) > 0).sum(), dtype=np.int64)
 

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/validate_soma.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/validate_soma.py
@@ -329,11 +329,15 @@ def _validate_X_obs_axis_stats(
 
     # obs.nnz
     nnz = expected_X.getnnz(axis=1)
+    assert np.all(census_obs.nnz.to_numpy() > 0.0)  # All cells must contain at least one count value > 0
     assert np.array_equal(census_obs.nnz.to_numpy(), nnz), f"{eb.name}:{dataset.dataset_id} obs.nnz incorrect."
 
     # obs.raw_mean_nnz - mean of the explicitly stored values (zeros are _ignored_)
+    with np.errstate(divide="ignore"):
+        expected_raw_mean_nnz = raw_sum / nnz
+    expected_raw_mean_nnz[~np.isfinite(expected_raw_mean_nnz)] = 0.0
     assert np.allclose(
-        census_obs.raw_mean_nnz.to_numpy(), raw_sum / nnz
+        census_obs.raw_mean_nnz.to_numpy(), expected_raw_mean_nnz
     ), f"{eb.name}:{dataset.dataset_id} obs.raw_mean_nnz incorrect."
 
     # obs.raw_variance_nnz

--- a/tools/cellxgene_census_builder/tests/conftest.py
+++ b/tools/cellxgene_census_builder/tests/conftest.py
@@ -33,6 +33,14 @@ def get_h5ad(organism: Organism, gene_ids: Optional[List[str]] = None) -> anndat
     n_genes = len(gene_ids)
     rng = np.random.default_rng()
     X = rng.integers(5, size=(n_cells, n_genes)).astype(np.float32)
+
+    # Builder code currently assumes (and enforces) that ALL cells (rows) contain at least
+    # one non-zero value in their count matrix. Enforce this assumption, as the rng will
+    # occasionally generate row that sums to zero.
+    zero_sum_rows = X.sum(axis=1) == 0
+    X[zero_sum_rows, :][:, rng.integers(X.shape[1])] = 1.0
+    assert np.all(X.sum(axis=1) > 0.0)
+
     # The builder only supports sparse matrices
     X = sparse.csr_matrix(X)
 


### PR DESCRIPTION
Unit tests would occasionally fail when a synthetic X count matrix contained no values (i.e. X.sum(axis=1) contained a zero value).

Changes:
* fix unit tests to always generate X counts with at least one non-zero count for each cell
* enforce this assumption for all cells included in the Census
* clean up potential divide-by-zero values in axis stat calculations (should never occur with above assumption, but good code hygiene)

Fixes #741