### PR TITLE
revert Mac M1/M2 cert fix on open_soma()

### DIFF
--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -38,8 +38,6 @@ dependencies= [
     "typing_extensions",
     "s3fs>=2021.06.1",
     "scipy<1.11",  # work around incompatibility between scipy and pyarrow
-    # Temporary fix for Mac OSX, to be removed by https://github.com/chanzuckerberg/cellxgene-census/issues/415
-    "certifi",
 ]
 
 [project.optional-dependencies]

--- a/api/python/cellxgene_census/src/cellxgene_census/_open.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/_open.py
@@ -11,7 +11,6 @@ import os.path
 import urllib.parse
 from typing import Any, Dict, Optional, get_args
 
-import certifi
 import s3fs
 import tiledbsoma as soma
 
@@ -31,8 +30,6 @@ DEFAULT_TILEDB_CONFIGURATION: Dict[str, Any] = {
     # https://docs.tiledb.com/main/how-to/configuration#configuration-parameters
     "py.init_buffer_bytes": 1 * 1024**3,
     "soma.init_buffer_bytes": 1 * 1024**3,
-    # Temporary fix for Mac OSX, to be removed by https://github.com/chanzuckerberg/cellxgene-census/issues/415
-    "vfs.s3.ca_file": certifi.where(),
 }
 
 api_logger = logging.getLogger("cellxgene_census")


### PR DESCRIPTION
Fixed #415 

Tested on M1 via installation of a locally built wheel.