### PR TITLE
[builder] thread usage tuning

### DIFF
--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/globals.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/globals.py
@@ -5,6 +5,8 @@ import pyarrow as pa
 import tiledb
 import tiledbsoma as soma
 
+from ..util import cpu_count
+
 CENSUS_SCHEMA_VERSION = "1.2.0"
 
 CXG_SCHEMA_VERSION = "3.1.0"  # the CELLxGENE schema version supported
@@ -336,6 +338,13 @@ DEFAULT_TILEDB_CONFIG = {
     "py.deduplicate": "true",
     "soma.init_buffer_bytes": 1 * 1024**3,
     "sm.consolidation.buffer_size": 3 * 1024**3,
+    "sm.mem.reader.sparse_global_order.ratio_array_data": 0.3,
+    #
+    # Concurrency levels are capped for high-CPU boxes. Left unchecked, some
+    # of the largest host configs can bump into Linux kernel thread limits,
+    # without any real benefit to overall performance.
+    "sm.compute_concurrency_level": min(cpu_count(), 64),
+    "sm.io_concurrency_level": min(cpu_count(), 64),
 }
 
 

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/globals.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/globals.py
@@ -333,6 +333,7 @@ FEATURE_REFERENCE_IGNORE: Set[str] = set()
 
 
 # The default configuration for TileDB contexts used in the builder.
+# Ref: https://docs.tiledb.com/main/how-to/configuration#configuration-parameters
 DEFAULT_TILEDB_CONFIG = {
     "py.init_buffer_bytes": 1 * 1024**3,
     "py.deduplicate": "true",

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/util.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/util.py
@@ -73,7 +73,9 @@ def env_var_init() -> None:
     if "NUMEXPR_MAX_THREADS" not in os.environ:
         # ref: https://numexpr.readthedocs.io/en/latest/user_guide.html#threadpool-configuration
         # In particular, the docs state that >8 threads is not helpful except in extreme circumstances.
-        os.environ["NUMEXPR_MAX_THREADS"] = str(min(8, max(1, cpu_count() // 2)))
+        val = str(min(8, max(1, cpu_count() // 2)))
+        os.environ["NUMEXPR_MAX_THREADS"] = val
+        logging.info(f'Setting NUMEXPR_MAX_THREADS environment variable to "{val}"')
 
     for env_name in [
         "OMP_NUM_THREADS",

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/util.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/util.py
@@ -41,12 +41,25 @@ def urlcat(base: str, *paths: str) -> str:
     return url
 
 
-def env_var_init(args: CensusBuildArgs) -> None:
+def env_var_init() -> None:
     """
     Set environment variables as needed by dependencies, etc.
+
+    This controls thread allocation for worker (child) processes. It is executed too
+    late to influence __init__ time thread pool allocations for the main process.
     """
     if "NUMEXPR_MAX_THREADS" not in os.environ:
-        os.environ["NUMEXPR_MAX_THREADS"] = str(min(1, cpu_count() // 2))
+        # ref: https://numexpr.readthedocs.io/en/latest/user_guide.html#threadpool-configuration
+        # In particular, the docs state that >8 threads is not helpful except in extreme circumstances.
+        os.environ["NUMEXPR_MAX_THREADS"] = str(min(8, max(1, cpu_count() // 2)))
+
+    # Each of these control thread-pool allocation for commonly used packages that
+    # may be pulled into our environment, and which have import-time pool allocation.
+    # Where we are confident we have no performance dependency related to their concurrency,
+    # set their pool size to "1".
+    for env_name in ["OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS", "VECLIB_MAXIMUM_THREADS"]:
+        if env_name not in os.environ:
+            os.environ[env_name] = "1"
 
 
 def process_init(args: CensusBuildArgs) -> None:
@@ -58,7 +71,7 @@ def process_init(args: CensusBuildArgs) -> None:
     if multiprocessing.get_start_method(True) != "spawn":
         multiprocessing.set_start_method("spawn", True)
 
-    env_var_init(args)
+    env_var_init()
 
     # these are super noisy!
     numba_logger = logging.getLogger("numba")

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/util.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/util.py
@@ -82,6 +82,7 @@ def env_var_init() -> None:
         "VECLIB_MAXIMUM_THREADS",
     ]:
         if env_name not in os.environ:
+            logging.info(f'Setting {env_name} environment variable to "1"')
             os.environ[env_name] = "1"
 
 


### PR DESCRIPTION
This PR adds configuration for thread usage, focused on lowering the number of unused threads on very high CPU count boxes.  Changes:
* set environment variables which configure load-time thread pool allocation for imported sub-modules. Example:  OpenMP
* cap TileDB and NumExpr thread pools to a useful number

Fixes #755 

Related to single-cell-data/TileDB-SOMA#1550

Note to reviewers: I have run a full build and there is no observed performance degradation.
