### PR TITLE
support tiledb config overrides in builder config

### DIFF
--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/__main__.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/__main__.py
@@ -8,6 +8,8 @@ from urllib.parse import urlparse
 
 import s3fs
 
+from tools.cellxgene_census_builder.src.cellxgene_census_builder.build_soma.globals import DEFAULT_TILEDB_CONFIG
+
 from .build_state import CENSUS_BUILD_CONFIG, CENSUS_BUILD_STATE, CensusBuildArgs, CensusBuildConfig, CensusBuildState
 from .util import log_process_resource_status, process_init, urlcat
 
@@ -35,6 +37,9 @@ def main() -> int:
         build_state = CensusBuildState.load(working_dir / CENSUS_BUILD_STATE)
 
     build_args = CensusBuildArgs(working_dir=working_dir, config=build_config, state=build_state)
+
+    # Update TileDB config defaults
+    DEFAULT_TILEDB_CONFIG.update(build_config.tiledb_config)
 
     # Process initialization/setup must be done early. NOTE: do NOT log before this line!
     process_init(build_args)

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_state.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_state.py
@@ -4,10 +4,11 @@ Manage the configuration and dynamic build state for the Census build.
 """
 import functools
 import io
+import json
 import os
 import pathlib
 from datetime import datetime
-from typing import Any, Iterator, Mapping, Union
+from typing import Any, Dict, Iterator, Mapping, Union
 
 import psutil
 import yaml
@@ -27,6 +28,8 @@ class CensusBuildConfig:
     verbose: int = field(converter=int, default=1)
     log_dir: str = field(default="logs")
     log_file: str = field(default="build.log")
+    # Overrides for TileDB config defaults (globals.py.DEFAULT_TILEDB_CONFIG)
+    tiledb_config: Dict[str, Any] = field(converter=json.loads, default={})
     reports_dir: str = field(default="reports")
     consolidate = field(converter=bool, default=True)
     disable_dirty_git_check = field(converter=bool, default=True)


### PR DESCRIPTION
Note: It ends up being quite a pain to thread the tiledb config changes needed to set the config level to all the places where the SomaTileDBContext is instantiated. So suggesting a global update of the defaults, using a new builder config param for arbitrary tiledb config overrides.