### PR TITLE
[builder] Add additional debug logging

### DIFF
--- a/tools/cellxgene_census_builder/entrypoint.sh
+++ b/tools/cellxgene_census_builder/entrypoint.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
+# Log tiledbsoma package versions
+python -c 'import tiledbsoma; print(tiledbsoma.show_package_versions())'
+
+# Log pip freeze 
+pip freeze
+
 python3 -m cellxgene_census_builder .
 BUILDER_STATUS=$?
 # On error, log dmesg tail to aid troubleshooting
 # Note: requires docker --privileged option
 if [[ $BUILDER_STATUS -ne 0 ]]; then dmesg | tail -n 128; fi
+if [[ $BUILDER_STATUS -ne 0 ]]; then df; fi
 exit $BUILDER_STATUS

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/__main__.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/__main__.py
@@ -2,14 +2,11 @@ import argparse
 import logging
 import os
 import pathlib
-import subprocess
 import sys
 from typing import Callable, Sequence
 from urllib.parse import urlparse
 
 import s3fs
-
-from tools.cellxgene_census_builder.src.cellxgene_census_builder.build_soma.globals import DEFAULT_TILEDB_CONFIG
 
 from .build_state import CENSUS_BUILD_CONFIG, CENSUS_BUILD_STATE, CensusBuildArgs, CensusBuildConfig, CensusBuildState
 from .util import log_process_resource_status, process_init, urlcat
@@ -52,7 +49,6 @@ def main() -> int:
         "build": [
             do_prebuild_set_defaults,
             do_prebuild_checks,
-            do_log_environment,
             do_build_soma,
             do_validate_soma,
             do_create_reports,
@@ -70,7 +66,6 @@ def main() -> int:
         "full-build": [
             do_prebuild_set_defaults,
             do_prebuild_checks,
-            do_log_environment,
             do_build_soma,
             do_validate_soma,
             do_create_reports,
@@ -155,30 +150,11 @@ def do_prebuild_checks(args: CensusBuildArgs) -> bool:
     return True
 
 
-def do_log_environment(args: CensusBuildArgs) -> bool:
-    # Log pip freeze output
-    import pkg_resources
-
-    deps = ""
-    for dep in pkg_resources.working_set:
-        deps += f"{dep.as_requirement()}\n"
-    logging.info(f"Pip freeze:\n{deps}")
-
-    # Log TileDB Config
-    logging.info(f"TileDB Config:\n{DEFAULT_TILEDB_CONFIG}")
-
-    return True
-
-
 def do_build_soma(args: CensusBuildArgs) -> bool:
     from .build_soma import build as build_a_soma
 
     if (cc := build_a_soma(args)) != 0:
         logging.critical(f"Build of census failed with code {cc}.")
-
-        # Log the output of df if a build fails
-        df = subprocess.run(["df"], capture_output=True, text=True)
-        logging.info(f"Disk space: {df.stdout}")
         return False
 
     return True


### PR DESCRIPTION
Add additional builder logging, namely: 

1. Output of `pip freeze`
2. TileDB configuration used
3. If the builder fails, output of `df` to check the disk space situation