### PR TITLE
[builder] perform all consolidation modes

### DIFF
--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/consolidate.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/consolidate.py
@@ -65,7 +65,19 @@ def consolidate_tiledb_object(uri: str) -> str:
     import tiledb
 
     logging.info(f"Consolidate: start uri {uri}")
-    tiledb.consolidate(uri, config=tiledb.Config(DEFAULT_TILEDB_CONFIG))
-    tiledb.vacuum(uri)
+
+    for mode in ["fragment_meta", "array_meta", "fragments", "commits"]:
+        ctx = tiledb.Ctx(
+            tiledb.Config(
+                {
+                    **DEFAULT_TILEDB_CONFIG,
+                    "sm.consolidation.mode": mode,
+                    "sm.vacuum.mode": mode,
+                }
+            )
+        )
+        tiledb.consolidate(uri, ctx=ctx)
+        tiledb.vacuum(uri, ctx=ctx)
+
     logging.info(f"Consolidate: end uri {uri}")
     return uri

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/consolidate.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/consolidate.py
@@ -2,11 +2,28 @@ import concurrent.futures
 import logging
 from typing import List
 
+import attrs
 import tiledbsoma as soma
 
 from ..build_state import CensusBuildArgs
 from .globals import DEFAULT_TILEDB_CONFIG, SOMA_TileDB_Context
 from .mp import create_process_pool_executor, log_on_broken_process_pool
+
+
+@attrs.define(kw_only=True, frozen=True)
+class ConsolidationCandidate:
+    uri: str
+    soma_type: str
+
+    def is_array(self) -> bool:
+        return self.soma_type in [
+            "SOMADataFrame",
+            "SOMASparseNDArray",
+            "SOMADenseNDArray",
+        ]
+
+    def is_group(self) -> bool:
+        return not self.is_array()
 
 
 def consolidate(args: CensusBuildArgs, uri: str) -> None:
@@ -22,7 +39,7 @@ def consolidate(args: CensusBuildArgs, uri: str) -> None:
     logging.info("Consolidate: finished")
 
 
-def _gather(uri: str) -> List[str]:
+def _gather(uri: str) -> List[ConsolidationCandidate]:
     # Gather URIs for any arrays that potentially need consolidation
     with soma.Collection.open(uri, context=SOMA_TileDB_Context()) as census:
         uris_to_consolidate = list_uris_to_consolidate(census)
@@ -30,7 +47,7 @@ def _gather(uri: str) -> List[str]:
     return uris_to_consolidate
 
 
-def _run(args: CensusBuildArgs, uris_to_consolidate: List[str]) -> None:
+def _run(args: CensusBuildArgs, uris_to_consolidate: List[ConsolidationCandidate]) -> None:
     # Queue consolidator for each array
     with create_process_pool_executor(args) as ppe:
         futures = [ppe.submit(consolidate_tiledb_object, uri) for uri in uris_to_consolidate]
@@ -43,41 +60,72 @@ def _run(args: CensusBuildArgs, uris_to_consolidate: List[str]) -> None:
             logging.info(f"Consolidate: completed [{n} of {len(futures)}]: {uri}")
 
 
-def list_uris_to_consolidate(collection: soma.Collection) -> List[str]:
+def list_uris_to_consolidate(
+    collection: soma.Collection,
+) -> List[ConsolidationCandidate]:
     """
-    Recursively walk the soma.Collection and return all uris for soma_types that can be consolidated.
+    Recursively walk the soma.Collection and return all uris for soma_types that can be consolidated and vacuumed.
     """
     uris = []
     for soma_obj in collection.values():
         type = soma_obj.soma_type
-        if type in ["SOMADataFrame", "SOMASparseNDArray", "SOMADenseNDArray"]:
-            uris.append(soma_obj.uri)
-        elif type in ["SOMACollection", "SOMAExperiment", "SOMAMeasurement"]:
-            uris += list_uris_to_consolidate(soma_obj)
-        else:
+        if type not in [
+            "SOMACollection",
+            "SOMAExperiment",
+            "SOMAMeasurement",
+            "SOMADataFrame",
+            "SOMASparseNDArray",
+            "SOMADenseNDArray",
+        ]:
             raise TypeError(f"Unknown SOMA type {type}.")
+
+        if type in ["SOMACollection", "SOMAExperiment", "SOMAMeasurement"]:
+            uris += list_uris_to_consolidate(soma_obj)
+        uris.append(ConsolidationCandidate(uri=soma_obj.uri, soma_type=type))
+
     return uris
 
 
-def consolidate_tiledb_object(uri: str) -> str:
+def consolidate_tiledb_object(obj: ConsolidationCandidate) -> str:
     assert soma.get_storage_engine() == "tiledb"
 
     import tiledb
 
-    logging.info(f"Consolidate: start uri {uri}")
+    uri = obj.uri
+    if obj.is_array():
+        modes = ["fragment_meta", "array_meta", "fragments", "commits"]
+    else:
+        # TODO: There is a bug in TileDB-Py that prevents consolidation of
+        # group metadata. Skipping this step for now - remove this work-around
+        # when the bug is fixed. As of 0.23.0, it is not yet fixed.
+        #
+        # modes = ["group_meta"]
+        modes = []
 
-    for mode in ["fragment_meta", "array_meta", "fragments", "commits"]:
-        ctx = tiledb.Ctx(
-            tiledb.Config(
-                {
-                    **DEFAULT_TILEDB_CONFIG,
-                    "sm.consolidation.mode": mode,
-                    "sm.vacuum.mode": mode,
-                }
+    # Possible future enhancement - cap fragment size. Increases number of
+    # fragments, with unknown perf hit, but could make some ops simpler.
+    # For example, this caps each fragment at approximately 10GiB.
+    #   "sm.consolidation.max_fragment_size": 10 * 1024**3,
+
+    for mode in modes:
+        try:
+            ctx = tiledb.Ctx(
+                tiledb.Config(
+                    {
+                        **DEFAULT_TILEDB_CONFIG,
+                        "sm.consolidation.buffer_size": 3 * 1024**3,
+                        "sm.consolidation.mode": mode,
+                        "sm.vacuum.mode": mode,
+                    }
+                )
             )
-        )
-        tiledb.consolidate(uri, ctx=ctx)
-        tiledb.vacuum(uri, ctx=ctx)
+            logging.info(f"Consolidate: start mode={mode}, uri={uri}")
+            tiledb.consolidate(uri, ctx=ctx)
+            logging.info(f"Vacuum: start mode={mode}, uri={uri}")
+            tiledb.vacuum(uri, ctx=ctx)
+        except tiledb.TileDBError as e:
+            logging.error(f"Consolidation error, uri={uri}: {str(e)}")
+            raise
 
-    logging.info(f"Consolidate: end uri {uri}")
+    logging.info(f"Consolidate/vacuum: end uri={uri}")
     return uri

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/globals.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/globals.py
@@ -338,7 +338,6 @@ DEFAULT_TILEDB_CONFIG = {
     "py.init_buffer_bytes": 1 * 1024**3,
     "py.deduplicate": "true",
     "soma.init_buffer_bytes": 1 * 1024**3,
-    "sm.consolidation.buffer_size": 3 * 1024**3,
     "sm.mem.reader.sparse_global_order.ratio_array_data": 0.3,
     #
     # Concurrency levels are capped for high-CPU boxes. Left unchecked, some

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/validate_soma.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/validate_soma.py
@@ -711,7 +711,7 @@ def validate_consolidation(soma_path: str) -> bool:
             return A.nonempty_domain() is None
 
     with soma.Collection.open(soma_path, context=SOMA_TileDB_Context()) as census:
-        consolidated_uris = list_uris_to_consolidate(census)
+        consolidated_uris = [obj.uri for obj in list_uris_to_consolidate(census) if obj.is_array()]
         for uri in consolidated_uris:
             # If an empty array, must have fragment count of zero. If a non-empty array,
             # must have fragment count of one.


### PR DESCRIPTION
Fixes #772 

Consolidation has multiple modes, for each type of object and metadata.  This PR adds consolidation/vacuuming of all modes. This does not add any substantial time to the build, as we were already doing the expensive consolidation steps.

Note: there is a bug in TileDB-Py that prevents the consolidation/vacuuming of group metadata. Reported and awaiting fix.  Disabling this step until such time as it is resolved - with work item captured in #776.