### PR TITLE
[python] limit runtime of --expensive unit tests

### DIFF
--- a/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
+++ b/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
@@ -94,15 +94,26 @@ def test_hvg_vs_scanpy(
 @pytest.mark.experimental
 @pytest.mark.live_corpus
 @pytest.mark.parametrize(
-    "experiment_name,organism,obs_value_filter,batch_key",
+    "experiment_name,organism,obs_value_filter,batch_key,obs_coords",
     [
-        ("mus_musculus", "Mus musculus", 'tissue_general == "liver" and is_primary_data == True', None),
-        ("mus_musculus", "Mus musculus", 'is_primary_data == True and tissue_general == "heart"', "cell_type"),
+        ("mus_musculus", "Mus musculus", 'tissue_general == "liver" and is_primary_data == True', None, None),
+        ("mus_musculus", "Mus musculus", 'is_primary_data == True and tissue_general == "heart"', "cell_type", None),
+        ("mus_musculus", "Mus musculus", 'is_primary_data == True and tissue_general == "heart"', "dataset_id", None),
         pytest.param(
-            "mus_musculus", "Mus musculus", "is_primary_data == True", "dataset_id", marks=pytest.mark.expensive
+            "mus_musculus",
+            "Mus musculus",
+            "is_primary_data == True",
+            "dataset_id",
+            slice(500_000, 1_000_000),
+            marks=pytest.mark.expensive,
         ),
         pytest.param(
-            "homo_sapiens", "Homo sapiens", "is_primary_data == True", "dataset_id", marks=pytest.mark.expensive
+            "homo_sapiens",
+            "Homo sapiens",
+            "is_primary_data == True",
+            "dataset_id",
+            slice(500_000, 1_000_000),
+            marks=pytest.mark.expensive,
         ),
     ],
 )
@@ -112,10 +123,16 @@ def test_get_highly_variable_genes(
     obs_value_filter: str,
     batch_key: str,
     small_mem_context: soma.SOMATileDBContext,
+    obs_coords: Optional[slice],
 ) -> None:
     with cellxgene_census.open_soma(census_version="stable", context=small_mem_context) as census:
         hvg = get_highly_variable_genes(
-            census, organism=organism, obs_value_filter=obs_value_filter, n_top_genes=1000, batch_key=batch_key
+            census,
+            organism=organism,
+            obs_value_filter=obs_value_filter,
+            n_top_genes=1000,
+            batch_key=batch_key,
+            obs_coords=obs_coords,
         )
         n_vars = census["census_data"][experiment_name].ms["RNA"].var.count
 

--- a/api/python/cellxgene_census/tests/experimental/pp/test_stats.py
+++ b/api/python/cellxgene_census/tests/experimental/pp/test_stats.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -41,7 +41,7 @@ def test_mean_variance(
     calc_mean: bool,
     calc_variance: bool,
     small_mem_context: soma.SOMATileDBContext,
-    obs_coords: tuple[None, slice],
+    obs_coords: Tuple[None, slice],
 ) -> None:
     with cellxgene_census.open_soma(census_version="latest", context=small_mem_context) as census:
         with census["census_data"][experiment_name].axis_query(

--- a/api/python/cellxgene_census/tests/experimental/pp/test_stats.py
+++ b/api/python/cellxgene_census/tests/experimental/pp/test_stats.py
@@ -26,12 +26,12 @@ def var(X: Union[sparse.csc_matrix, sparse.csr_matrix], axis: int = 0, ddof: int
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize("calc_mean,calc_variance", [(True, True), (True, False), (False, True)])
 @pytest.mark.parametrize(
-    "experiment_name,obs_value_filter",
+    "experiment_name,obs_value_filter,obs_coords",
     [
-        ("mus_musculus", 'tissue_general == "liver" and is_primary_data == True'),
-        ("mus_musculus", 'is_primary_data == True and tissue_general == "heart"'),
-        pytest.param("mus_musculus", "is_primary_data == True", marks=pytest.mark.expensive),
-        pytest.param("homo_sapiens", "is_primary_data == True", marks=pytest.mark.expensive),
+        ("mus_musculus", 'tissue_general == "liver" and is_primary_data == True', ()),
+        ("mus_musculus", 'is_primary_data == True and tissue_general == "heart"', ()),
+        pytest.param("mus_musculus", "is_primary_data == True", (slice(0, 400_000),), marks=pytest.mark.expensive),
+        pytest.param("homo_sapiens", "is_primary_data == True", (slice(0, 400_000),), marks=pytest.mark.expensive),
     ],
 )
 def test_mean_variance(
@@ -41,10 +41,11 @@ def test_mean_variance(
     calc_mean: bool,
     calc_variance: bool,
     small_mem_context: soma.SOMATileDBContext,
+    obs_coords: tuple[None, slice],
 ) -> None:
     with cellxgene_census.open_soma(census_version="latest", context=small_mem_context) as census:
         with census["census_data"][experiment_name].axis_query(
-            measurement_name="RNA", obs_query=soma.AxisQuery(value_filter=obs_value_filter)
+            measurement_name="RNA", obs_query=soma.AxisQuery(value_filter=obs_value_filter, coords=obs_coords)
         ) as query:
             mean_variance = pp.mean_variance(
                 query, calculate_mean=calc_mean, calculate_variance=calc_variance, axis=axis


### PR DESCRIPTION
We have several `--expensive` unit tests, used for acceptance testing upstream packages such as tiledbsoma.  As the Census has grown, their run-times have gotten out of control.  

This PR adds caps on the max size of the queries performed by a handful of the tests, to keep their run time reasonable.  The primary mechanism is to add an obs coordinate range to queries, restricting them to some maximum number of results.