### PR TITLE
LTS / package compatibility check

### DIFF
--- a/.github/workflows/lts-compat-check.yml
+++ b/.github/workflows/lts-compat-check.yml
@@ -12,10 +12,22 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]  # [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: ["3.11"]
-        census-build-version: ["latest", "stable", "2023-07-25", "2023-05-15"]
-        py-pkg-version: ["~=1.6.0", "head-of-main"]  # ["==1.0.0", "~=1.0.0", "~=1.1.0", "~=1.2.0", "~=1.3.0", "~=1.4.0", "~=1.5.0", "~=1.6.0", "head-of-main"]
+        census-build-version:
+          - "latest"
+          - "stable"
+          - "2023-07-25"
+          - "2023-05-15"
+        py-pkg-version:
+          - "~=1.0.0"
+          - "~=1.1.0"
+          - "~=1.2.0"
+          - "~=1.3.0"
+          - "~=1.4.0"
+          - "~=1.5.0"
+          - "~=1.6.0"
+          - "head-of-main"
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/lts-compat-check.yml
+++ b/.github/workflows/lts-compat-check.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]  # [ubuntu-latest, macos-latest]
         python-version: ["3.11"]
-        census-version: [latest]  # ["latest", "stable", "2023-07-25", "2023-05-15"]
-        cellxgene-census-version: ["~=1.6.0", "head-of-main"]  # ["==1.0.0", "~=1.0.0", "~=1.1.0", "~=1.2.0", "~=1.3.0", "~=1.4.0", "~=1.5.0", "~=1.6.0", "head-of-main"]
+        census-build-version: [latest]  # ["latest", "stable", "2023-07-25", "2023-05-15"]
+        py-pkg-version: ["~=1.6.0", "head-of-main"]  # ["==1.0.0", "~=1.0.0", "~=1.1.0", "~=1.2.0", "~=1.3.0", "~=1.4.0", "~=1.5.0", "~=1.6.0", "head-of-main"]
 
     runs-on: ${{matrix.os}}
 
@@ -29,15 +29,15 @@ jobs:
 
       - name: Install dependencies (including experimental)
         run: |
-          python -m pip install -U pip setuptools wheel pytest
-          # pip install -r ./api/python/cellxgene_census/scripts/requirements-dev.txt
+          python -m pip install -U pip setuptools wheel
+          pip install -r ./api/python/cellxgene_census/scripts/requirements-dev.txt
 
           if [ {{matrix.cellxgene-census-version}} != "head-of-main" ]; then
-            pip install -e './api/python/cellxgene_census/'
+            pip install -e ./api/python/cellxgene_census/[experimental]
           else
-            pip install -U cellxgene_census=={{matrix.cellxgene-census-version}}
+            pip install -U cellxgene_census[experimental]==${{ matrix.py-pkg-version }}
           fi
 
       - name: Test with pytest (API, main tests)
         run: |
-          PYTHONPATH=. pytest -v -rP -m lts_compat_check ./api/python/cellxgene_census/tests/ --census_version {{matrix.census-version}}
+          PYTHONPATH=. pytest -v -rP -m lts_compat_check ./api/python/cellxgene_census/tests/ --census_version ${{ matrix.census-build-version }}

--- a/.github/workflows/lts-compat-check.yml
+++ b/.github/workflows/lts-compat-check.yml
@@ -1,0 +1,43 @@
+name: Compat test between Census package and LTS builds
+
+on:
+  pull_request:  # TODO: remove befor landing
+  # schedule:
+  #   - cron: "30 1 * * *"
+  # workflow_dispatch: # used for debugging or manual validation
+  
+jobs:
+  python-compat-check:
+    name: Python LTS compatibility check
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11"]
+        census-version: ["latest", "stable", "2023-07-25", "2023-05-15"]
+        cellxgene-census-version: ["==1.0.0", "~=1.0.0", "~=1.1.0", "~=1.2.0", "~=1.3.0", "~=1.4.0", "~=1.5.0", "~=1.6.0", "head-of-main"]
+
+    runs-on: ${{matrix.os}}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies (including experimental)
+        run: |
+          python -m pip install -U pip setuptools wheel
+          pip install -r ./api/python/cellxgene_census/scripts/requirements-dev.txt
+
+          if [ {{matrix.cellxgene-census-version}} != "head-of-main" ]; then
+            pip install -e './api/python/cellxgene_census/'
+          else
+            pip install -U cellxgene_census=={{matrix.cellxgene-census-version}}
+          fi
+
+      - name: Test with pytest (API, main tests)
+        run: |
+          PYTHONPATH=. pytest -v -rP -m lts_compat_check ./api/python/cellxgene_census/tests/ --census_version {{matrix.census-version}}

--- a/.github/workflows/lts-compat-check.yml
+++ b/.github/workflows/lts-compat-check.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]  # [ubuntu-latest, macos-latest]
         python-version: ["3.11"]
-        census-build-version: [latest]  # ["latest", "stable", "2023-07-25", "2023-05-15"]
+        census-build-version: ["latest", "stable", "2023-07-25", "2023-05-15"]
         py-pkg-version: ["~=1.6.0", "head-of-main"]  # ["==1.0.0", "~=1.0.0", "~=1.1.0", "~=1.2.0", "~=1.3.0", "~=1.4.0", "~=1.5.0", "~=1.6.0", "head-of-main"]
 
     runs-on: ${{matrix.os}}

--- a/.github/workflows/lts-compat-check.yml
+++ b/.github/workflows/lts-compat-check.yml
@@ -2,9 +2,9 @@ name: Compat test between Census package and LTS builds
 
 on:
   pull_request:  # TODO: remove befor landing
-  # schedule:
-  #   - cron: "30 1 * * *"
-  # workflow_dispatch: # used for debugging or manual validation
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch: # used for debugging or manual validation
   
 jobs:
   python-compat-check:
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.11"]
-        census-build-version:
+        census-build-version:  # Add additional LTS releases as they occur
           - "latest"
           - "stable"
           - "2023-07-25"

--- a/.github/workflows/lts-compat-check.yml
+++ b/.github/workflows/lts-compat-check.yml
@@ -12,10 +12,10 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]  # [ubuntu-latest, macos-latest]
         python-version: ["3.11"]
-        census-version: ["latest", "stable", "2023-07-25", "2023-05-15"]
-        cellxgene-census-version: ["==1.0.0", "~=1.0.0", "~=1.1.0", "~=1.2.0", "~=1.3.0", "~=1.4.0", "~=1.5.0", "~=1.6.0", "head-of-main"]
+        census-version: [latest]  # ["latest", "stable", "2023-07-25", "2023-05-15"]
+        cellxgene-census-version: ["~=1.6.0", "head-of-main"]  # ["==1.0.0", "~=1.0.0", "~=1.1.0", "~=1.2.0", "~=1.3.0", "~=1.4.0", "~=1.5.0", "~=1.6.0", "head-of-main"]
 
     runs-on: ${{matrix.os}}
 
@@ -29,8 +29,8 @@ jobs:
 
       - name: Install dependencies (including experimental)
         run: |
-          python -m pip install -U pip setuptools wheel
-          pip install -r ./api/python/cellxgene_census/scripts/requirements-dev.txt
+          python -m pip install -U pip setuptools wheel pytest
+          # pip install -r ./api/python/cellxgene_census/scripts/requirements-dev.txt
 
           if [ {{matrix.cellxgene-census-version}} != "head-of-main" ]; then
             pip install -e './api/python/cellxgene_census/'

--- a/.github/workflows/lts-compat-check.yml
+++ b/.github/workflows/lts-compat-check.yml
@@ -1,7 +1,6 @@
 name: Compat test between Census package and LTS builds
 
 on:
-  pull_request:  # TODO: remove befor landing
   schedule:
     - cron: "30 1 * * *"
   workflow_dispatch: # used for debugging or manual validation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![codecov](https://codecov.io/gh/chanzuckerberg/cellxgene-census/branch/main/graph/badge.svg?token=byX1pyDlc9)](https://codecov.io/gh/chanzuckerberg/cellxgene-census)
 [![Python dependency checks](https://github.com/chanzuckerberg/cellxgene-census/actions/workflows/py-dependency-check.yml/badge.svg)](https://github.com/chanzuckerberg/cellxgene-census/actions/workflows/py-dependency-check.yml)
+[![LTS compat checks](https://github.com/chanzuckerberg/cellxgene-census/actions/workflows/lts-compat-check.yml/badge.svg)](https://github.com/chanzuckerberg/cellxgene-census/actions/workflows/lts-compat-check.yml)
 
 # CZ CELLxGENE Discover Census
 

--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -82,6 +82,7 @@ markers = [
     "live_corpus: runs on the live CELLxGENE Census data corpus and small enough to run in CI",
     "expensive: too expensive to run regularly or in CI",
     "experimental: tests for the `experimental` package",
+    "lts_compat_check: check for compatibility with an LTS build",
 ]
 
 [tool.ruff]

--- a/api/python/cellxgene_census/tests/conftest.py
+++ b/api/python/cellxgene_census/tests/conftest.py
@@ -14,6 +14,18 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             help=f"enable '{test_option}' decorated tests",
         )
 
+    # Add option to set the census_version (not set by default)
+    parser.addoption("--census_version", action="store", default="stable")
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    """This is called for every test"""
+
+    # Configure census_version if used
+    census_version = metafunc.config.option.census_version
+    if "census_version" in metafunc.fixturenames:
+        metafunc.parametrize("census_version", [census_version])
+
 
 def pytest_configure(config: pytest.Config) -> None:
     """

--- a/api/python/cellxgene_census/tests/test_lts_compat.py
+++ b/api/python/cellxgene_census/tests/test_lts_compat.py
@@ -1,0 +1,17 @@
+"""
+Compatibility tests between the installed verison of cellxgene-census and
+a named LTS release. Primarilly intended to be driven by a periodic GHA.
+
+Where there are known and accepted incompatibilities, use `pytest.skipif`
+"""
+
+import pytest
+
+import cellxgene_census
+
+
+@pytest.mark.lts_compat_check
+def test_open(census_version: str) -> None:
+    print("census-version", census_version)
+    with cellxgene_census.open_soma(census_version=census_version) as census:
+        assert repr(census)

--- a/api/python/cellxgene_census/tests/test_lts_compat.py
+++ b/api/python/cellxgene_census/tests/test_lts_compat.py
@@ -2,7 +2,8 @@
 Compatibility tests between the installed verison of cellxgene-census and
 a named LTS release. Primarilly intended to be driven by a periodic GHA.
 
-Where there are known and accepted incompatibilities, use `pytest.skipif`
+Where there are known and accepted incompatibilities, use `pytest.skip`
+to codify them.
 """
 from __future__ import annotations
 

--- a/api/python/cellxgene_census/tests/test_lts_compat.py
+++ b/api/python/cellxgene_census/tests/test_lts_compat.py
@@ -4,14 +4,86 @@ a named LTS release. Primarilly intended to be driven by a periodic GHA.
 
 Where there are known and accepted incompatibilities, use `pytest.skipif`
 """
+from __future__ import annotations
 
+from collections import deque
+from typing import Iterator, Literal, Optional, Sequence, Union, get_args
+
+import pyarrow as pa
 import pytest
+import tiledbsoma as soma
 
 import cellxgene_census
+
+SOMATypeNames = Literal[
+    "SOMACollection", "SOMAExperiment", "SOMAMeasurement", "SOMADataFrame", "SOMASparseNDArray", "SOMADenseNDArray"
+]
+CollectionTypeNames = ["SOMACollection", "SOMAExperiment", "SOMAMeasurement"]
+
+SOMATypes = Union[
+    soma.Collection, soma.DataFrame, soma.SparseNDArray, soma.DenseNDArray, soma.Experiment, soma.Measurement
+]
+
+
+def walk_census(
+    census: soma.Collection, filter_types: Optional[Sequence[SOMATypeNames]] = None
+) -> Iterator[tuple[str, SOMATypes]]:
+    assert census.soma_type == "SOMACollection"
+    filter_types = filter_types or get_args(SOMATypeNames)
+    items_to_check = deque([("census", census)])
+    while items_to_check:
+        key, val = items_to_check.popleft()
+        if val.soma_type in CollectionTypeNames:
+            items_to_check.extend(val.items())
+
+        if val.soma_type not in filter_types:
+            continue
+
+        yield key, val
 
 
 @pytest.mark.lts_compat_check
 def test_open(census_version: str) -> None:
-    print("census-version", census_version)
+    """
+    Verify we can open and walk the collections, get metadata and read schema on non-collections
+    """
+
     with cellxgene_census.open_soma(census_version=census_version) as census:
-        assert repr(census)
+        for name, item in walk_census(census):
+            assert name
+            assert list(item.metadata)
+            if item.soma_type not in CollectionTypeNames:
+                assert isinstance(item.schema, pa.Schema)
+
+
+@pytest.mark.lts_compat_check
+def test_read_dataframe(census_version: str) -> None:
+    """
+    Verify we can read at least one row of dataframes
+    """
+    with cellxgene_census.open_soma(census_version=census_version) as census:
+        for name, sdf in walk_census(census, filter_types=["SOMADataFrame"]):
+            assert name
+            # the Census should have no zero-length DataFrames
+            assert len(sdf)
+            df = sdf.read(coords=([0],)).concat().to_pandas()
+            assert len(df) == 1
+            assert df.shape == (1, len(sdf.keys()))
+
+
+@pytest.mark.lts_compat_check
+def test_read_arrays(census_version: str) -> None:
+    """
+    Verify we can read from NDArray
+    """
+    with cellxgene_census.open_soma(census_version=census_version) as census:
+        for name, sarr in walk_census(census, filter_types=["SOMASparseNDArray", "SOMADenseNDArray"]):
+            assert name
+            assert isinstance(sarr.shape, tuple)
+
+            # There are currently no Census schema versions using DenseNDArray
+
+            assert sarr.soma_type == "SOMASparseNDArray"
+            assert sarr.nnz
+            tbl = sarr.read(coords=(slice(100),)).tables().concat()
+            assert len(tbl) > 0


### PR DESCRIPTION
Add a GHA that checks for compatibility between a matrix of:
* cellxgene_census package versions
* Census LTS versions

Intended to be run nightly as a canary for any incompatibility between past LTS releases and evolving access packages.

Note: down the road, if the matrix size gets out of control, we can always consolidate along the Census build axis and just have a loop that runs over all Census build versions in a single GHA.

FYI: @mlin - it may be worth considering adding something similar for the R package, although there are diminishing returns as both language bindings share a large common implementation base.