### PR TITLE
[builder] use TileDB core 2.16

### DIFF
--- a/tools/cellxgene_census_builder/pyproject.toml
+++ b/tools/cellxgene_census_builder/pyproject.toml
@@ -26,26 +26,26 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies= [
-    "typing_extensions==4.7.1",
-    "pyarrow==12.0.1",
+    "typing_extensions==4.8.0",
+    "pyarrow==13.0.0",
     "pandas[performance]==2.0.3",
-    "anndata==0.8",
+    "anndata==0.9",
     "numpy==1.23.5",
     # IMPORTANT: consider TileDB format compat before advancing this version.
     # IMPORTANT: do not update to cellxgene_census package until you want a new tiledbsoma/tiledb
-    "cellxgene_census==1.0.0", 
-    "scipy==1.10.1",  # 1.11 has compat issues with pyarrow
-    "fsspec==2023.6.0",
-    "s3fs==2023.6.0",
+    "cellxgene_census==1.5.1",
+    "scipy==1.10.1",  # cellxgene-census==1.5.1 forces scipy<1.11
+    "fsspec==2023.9.2",
+    "s3fs==2023.9.2",
     "requests==2.31.0",
-    "aiohttp==3.8.5",
+    "aiohttp==3.8.6",
     "Cython", # required by owlready2
     "wheel",  # required by owlready2
-    "owlready2==0.38",
-    "gitpython==3.1.32",
+    "owlready2==0.44",
+    "gitpython==3.1.37",
     "attrs==23.1.0",
     "psutil==5.9.5",
-    "pyyaml==6.0",
+    "pyyaml==6.0.1",
     "numba==0.56.4",
 ]
 


### PR DESCRIPTION
Fixes #799 

Update builder to use TileDB core 2.16.

Also updates other miscellaneous dependency pins to more recent versions, where there are no conflicts upstream.
