### PR TITLE
[python] remove unnecessary dependency pin

### DIFF
--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -37,7 +37,6 @@ dependencies= [
     "requests",
     "typing_extensions",
     "s3fs>=2021.06.1",
-    "scipy<1.11",  # work around incompatibility between scipy and pyarrow
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
In preparation for working on #801 and upgrading to the soon-to-arrive tiledbsoma 1.5, this cleans up unnecessary pins in our Python package dependencies. The SciPy pin was due to an old incompatibility with Arrow, now resolved.
