### PR TITLE
[misc] shorten Census LTS compatibility workflow name

### DIFF
--- a/.github/workflows/lts-compat-check.yml
+++ b/.github/workflows/lts-compat-check.yml
@@ -1,4 +1,4 @@
-name: Compat test between Census package and LTS builds
+name: Census LTS Compatibility  # Compat test between Census package and LTS builds
 
 on:
   schedule:


### PR DESCRIPTION
The full GHA name is displayed in the badge, which is shown on the top of the README.

Shorten to make the README a bit less verbose.