### PR TITLE
[builder] update tiledbsoma pin to 1.4.4

### DIFF
--- a/tools/cellxgene_census_builder/pyproject.toml
+++ b/tools/cellxgene_census_builder/pyproject.toml
@@ -31,9 +31,10 @@ dependencies= [
     "pandas[performance]==2.0.3",
     "anndata==0.9",
     "numpy==1.23.5",
-    # IMPORTANT: consider TileDB format compat before advancing this version.
-    # IMPORTANT: do not update to cellxgene_census package until you want a new tiledbsoma/tiledb
-    "cellxgene_census==1.5.1",
+    # IMPORTANT: consider TileDB format compat before advancing this version. It is important that
+    # IMPORTANT: the tiledbsoma version lag that used in cellxgene-census package.
+    "tiledbsoma==1.4.4",
+    "cellxgene-census==1.6.0",
     "scipy==1.10.1",  # cellxgene-census==1.5.1 forces scipy<1.11
     "fsspec==2023.9.2",
     "s3fs==2023.9.2",


### PR DESCRIPTION
Fixes #811 

Update the tiledbsoma pin to 1.4.4 to benefit from concurrency bug fix in that release.
