### PR TITLE
[python] temporarily skip geneformer tests

### DIFF
--- a/api/python/cellxgene_census/tests/experimental/ml/huggingface/test_geneformer.py
+++ b/api/python/cellxgene_census/tests/experimental/ml/huggingface/test_geneformer.py
@@ -20,6 +20,9 @@ def select_census_version_for_geneformer_tests() -> str:
     return "2023-09-04"
 
 
+@pytest.mark.skip(
+    "FIXME: 2023-09-04 Census release was deleted and cell soma_joinids have changed in subsequent versions"
+)
 @pytest.mark.experimental
 @pytest.mark.live_corpus
 @pytest.mark.parametrize(
@@ -68,6 +71,9 @@ def test_GeneformerTokenizer(cells_per_chunk: int) -> None:
                 assert row.tissue_ontology_term_id
 
 
+@pytest.mark.skip(
+    "FIXME: 2023-09-04 Census release was deleted and cell soma_joinids have changed in subsequent versions"
+)
 @pytest.mark.experimental
 @pytest.mark.live_corpus
 def test_GeneformerTokenizer_docstring_example() -> None:


### PR DESCRIPTION
Due to my neglecting to ask for do_not_delete to be set on a certain Census version the GeneformerTokenizer unit tests were coded against, it has now been deleted. The tests cannot use the current stable version because it doesn't have the normalized X layer. The tests also do not work against latest as the soma_joinids have changed.

I will need to overhaul this but it will probably take me a few days to get to, so marking the tests to skip in the meantime. Apologies all. (The overhaul may be an opportunity to switch to a token sequence checksumming approach suggested by Theodoris lab)