### PR TITLE
[python] Fix HVG crasher

### DIFF
--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/pp/_highly_variable_genes.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/pp/_highly_variable_genes.py
@@ -190,6 +190,7 @@ def _highly_variable_genes_seurat_v3(
                 acc.update(var_dim, data)
 
         counts_sum, squared_counts_sum = acc.finalize()
+        # Don't raise python errors for 0/0, etc, just generate Inf/NaN
         with np.errstate(divide="ignore", invalid="ignore"):
             norm_gene_vars = (1 / ((n_samples - 1) * np.square(reg_std.T))).T * (
                 (n_samples * np.square(batches_u.T)).T + squared_counts_sum - 2 * counts_sum * batches_u

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/pp/_online.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/pp/_online.py
@@ -66,7 +66,7 @@ class MeanVarianceAccumulator:
 
         # Note: if N-ddof is less than or equal to 0, we will return Inf - this is consistent
         # with the numpy.var behavior.
-        with np.errstate(divide="ignore"):
+        with np.errstate(divide="ignore", invalid="ignore"):
             batches_var = (self.M2.T / np.maximum(0, (self.n_samples - self.ddof))).T
 
         # accum all batches using Chan's

--- a/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
+++ b/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
@@ -22,7 +22,7 @@ from cellxgene_census.experimental.pp import (
     [
         (
             "mus_musculus",
-            'is_primary_data == True and tissue_general == "tongue"',
+            'is_primary_data == True and tissue_general == "liver"',
         ),
         pytest.param(
             "mus_musculus",

--- a/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
+++ b/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
@@ -111,6 +111,11 @@ def test_hvg_vs_scanpy(
     try:
         scanpy_hvg = sc.pp.highly_variable_genes(adata, inplace=False, **kwargs)
     except ZeroDivisionError:
+        # There are test cases where ScanPy will fail, rendering this "compare vs scanpy" 
+        # test moot. The known cases involve overly partitioned data that results in batches
+        # with a very small number of samples (which manifest as a divide by zero error).
+        # In these known cases, go ahead and perform the HVG (above), but skip the compare
+        # assertions below.
         pytest.skip("ScanPy generated an error, likely due to batches with 1 sample")
 
     scanpy_hvg.index.name = "soma_joinid"

--- a/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
+++ b/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
@@ -111,7 +111,7 @@ def test_hvg_vs_scanpy(
     try:
         scanpy_hvg = sc.pp.highly_variable_genes(adata, inplace=False, **kwargs)
     except ZeroDivisionError:
-        # There are test cases where ScanPy will fail, rendering this "compare vs scanpy" 
+        # There are test cases where ScanPy will fail, rendering this "compare vs scanpy"
         # test moot. The known cases involve overly partitioned data that results in batches
         # with a very small number of samples (which manifest as a divide by zero error).
         # In these known cases, go ahead and perform the HVG (above), but skip the compare

--- a/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
+++ b/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
@@ -22,7 +22,12 @@ from cellxgene_census.experimental.pp import (
     [
         (
             "mus_musculus",
+            'is_primary_data == True and tissue_general == "tongue"',
+        ),
+        pytest.param(
+            "mus_musculus",
             'is_primary_data == True and tissue_general == "skin of body"',
+            marks=pytest.mark.expensive,
         ),
         pytest.param(
             "mus_musculus",
@@ -53,8 +58,20 @@ from cellxgene_census.experimental.pp import (
         ),
     ),
 )
-@pytest.mark.parametrize("span", (None, 0.5))
-@pytest.mark.parametrize("version", ("latest", "stable"))
+@pytest.mark.parametrize(
+    "span",
+    (
+        pytest.param(None, marks=pytest.mark.expensive),
+        0.5,
+    ),
+)
+@pytest.mark.parametrize(
+    "version",
+    (
+        "latest",
+        pytest.param("stable", marks=pytest.mark.expensive),
+    ),
+)
 def test_hvg_vs_scanpy(
     n_top_genes: int,
     obs_value_filter: str,
@@ -102,10 +119,26 @@ def test_hvg_vs_scanpy(
     assert all(scanpy_hvg.keys() == hvg.keys())
 
     assert (hvg.index == scanpy_hvg.index).all()
-    assert np.allclose(hvg.means.to_numpy(), scanpy_hvg.means.to_numpy(), atol=1e-5, rtol=1e-2, equal_nan=True)
-    assert np.allclose(hvg.variances.to_numpy(), scanpy_hvg.variances.to_numpy(), atol=1e-5, rtol=1e-2, equal_nan=True)
     assert np.allclose(
-        hvg.variances_norm.to_numpy(), scanpy_hvg.variances_norm.to_numpy(), atol=1e-5, rtol=1e-2, equal_nan=True
+        hvg.means.to_numpy(),
+        scanpy_hvg.means.to_numpy(),
+        atol=1e-5,
+        rtol=1e-2,
+        equal_nan=True,
+    )
+    assert np.allclose(
+        hvg.variances.to_numpy(),
+        scanpy_hvg.variances.to_numpy(),
+        atol=1e-5,
+        rtol=1e-2,
+        equal_nan=True,
+    )
+    assert np.allclose(
+        hvg.variances_norm.to_numpy(),
+        scanpy_hvg.variances_norm.to_numpy(),
+        atol=1e-5,
+        rtol=1e-2,
+        equal_nan=True,
     )
 
     # Online calculation of normalized variance  will differ slightly from ScanPy's calculation,


### PR DESCRIPTION
Fixes #817 

loess.fit will crash with empty array input. Changes:
* correctly handle cases where batch key over-segments, resulting in batch sizes of zero or one
* fix several numerical precision/correctness issues found while debugging
* improve HVG unit tests, and allow for inevitable precision noise in "expensive" tests
* remove some expensive HVG unit tests from our standard CI (move to "expensive")
 