### PR TITLE
[python] add PEP 561 py.typed marker

### DIFF
--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -62,6 +62,9 @@ where = ["src"]
 include = ["cellxgene_census*"]  # package names should match these glob patterns (["*"] by default)
 exclude = ["tests*"]  # exclude packages matching these glob patterns (empty by default)
 
+[tool.setuptools.package-data]
+"cellxgene_census" = ["py.typed"]
+
 [tool.setuptools_scm]
 root = "../../.."
 

--- a/api/python/cellxgene_census/src/cellxgene_census/py.typed
+++ b/api/python/cellxgene_census/src/cellxgene_census/py.typed
@@ -1,1 +1,1 @@
-# Marker file for PEP 561.  The cellxgene_census package uses inline types.
+# Marker file for PEP 561. The cellxgene_census package uses inline types.

--- a/api/python/cellxgene_census/src/cellxgene_census/py.typed
+++ b/api/python/cellxgene_census/src/cellxgene_census/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  The cellxgene_census package uses inline types.


### PR DESCRIPTION
Fixes #806 

Add marker file indicating use of line typing for the cellxgene_census package.