### PR TITLE
fix installation of geneformer's transitive dependency in py-dependency-check.yml

### DIFF
--- a/.github/workflows/py-dependency-check.yml
+++ b/.github/workflows/py-dependency-check.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Install dependencies (including experimental)
         run: |
           python -m pip install -U pip setuptools wheel
+          pip install --use-pep517 accumulation-tree # Geneformer dependency needs --use-pep517 for Cython
           pip install -U -r ./api/python/cellxgene_census/scripts/requirements-dev.txt
           pip install -U cellxgene-census[experimental]
 

--- a/api/python/cellxgene_census/scripts/requirements-dev.txt
+++ b/api/python/cellxgene_census/scripts/requirements-dev.txt
@@ -4,3 +4,4 @@ requests-mock
 twine
 coverage
 nbqa
+git+https://huggingface.co/ctheodoris/Geneformer@39ab62e

--- a/api/python/cellxgene_census/scripts/requirements-dev.txt
+++ b/api/python/cellxgene_census/scripts/requirements-dev.txt
@@ -4,4 +4,3 @@ requests-mock
 twine
 coverage
 nbqa
-git+https://huggingface.co/ctheodoris/Geneformer@39ab62e


### PR DESCRIPTION
RE: #831 

Ports a workaround for installing a gnarly transitive dependency of Geneformer, [from py-unittests.yml](https://github.com/chanzuckerberg/cellxgene-census/blob/1d071d6e189a32c3a040e67a43e981ba7f082701/.github/workflows/py-unittests.yml#L28-L29) to py-dependency-check.yml.

Due to this dependency that's difficult on certain platforms (cython etc.), we leave Geneformer out of the pyproject.toml dependencies and instead raise [a runtime error](https://github.com/chanzuckerberg/cellxgene-census/blob/1d071d6e189a32c3a040e67a43e981ba7f082701/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/huggingface/geneformer_tokenizer.py#L104-L111) asking end users to install it when needed. However, we do need to install it in GHA in order to run the unit tests (which albeit are temporarily disabled for unrelated reasons #818). 

