### PR TITLE
Acceptance/Builder tests misc fixes

### DIFF
--- a/api/python/cellxgene_census/tests/test_acceptance.py
+++ b/api/python/cellxgene_census/tests/test_acceptance.py
@@ -26,6 +26,7 @@ def make_context(census_version: str, config: Optional[Dict[str, Any]] = None) -
     version = cellxgene_census.get_census_version_description(census_version)
     s3_region = version["soma"].get("s3_region", "us-west-2")
     config.update({"vfs.s3.region": s3_region})
+    config.update({"vfs.s3.no_sign_request": "true"})
     return soma.options.SOMATileDBContext(tiledb_ctx=tiledb.Ctx(config))
 
 

--- a/api/python/cellxgene_census/tests/test_acceptance.py
+++ b/api/python/cellxgene_census/tests/test_acceptance.py
@@ -26,7 +26,7 @@ def make_context(census_version: str, config: Optional[Dict[str, Any]] = None) -
     s3_region = version["soma"].get("s3_region", "us-west-2")
     config.update({"vfs.s3.region": s3_region})
     config.update({"vfs.s3.no_sign_request": "true"})
-    return soma.options.SOMATileDBContext(tiledb_ctx=config)
+    return soma.options.SOMATileDBContext().replace(**{"tiledb_config": config})
 
 
 @pytest.mark.live_corpus

--- a/api/python/cellxgene_census/tests/test_acceptance.py
+++ b/api/python/cellxgene_census/tests/test_acceptance.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, Iterator, Optional, Tuple
 
 import pyarrow as pa
 import pytest
-import tiledb
 import tiledbsoma as soma
 
 import cellxgene_census
@@ -27,7 +26,7 @@ def make_context(census_version: str, config: Optional[Dict[str, Any]] = None) -
     s3_region = version["soma"].get("s3_region", "us-west-2")
     config.update({"vfs.s3.region": s3_region})
     config.update({"vfs.s3.no_sign_request": "true"})
-    return soma.options.SOMATileDBContext(tiledb_ctx=tiledb.Ctx(config))
+    return soma.options.SOMATileDBContext(tiledb_ctx=config)
 
 
 @pytest.mark.live_corpus

--- a/tools/cellxgene_census_builder/tests/conftest.py
+++ b/tools/cellxgene_census_builder/tests/conftest.py
@@ -125,7 +125,7 @@ def datasets(census_build_args: CensusBuildArgs) -> List[Dataset]:
     datasets = []
     for organism in ORGANISMS:
         for i in range(NUM_DATASET):
-            h5ad = get_h5ad(organism, GENE_IDS[i])
+            h5ad = get_h5ad(organism, GENE_IDS[i], no_zero_counts=True)
             h5ad_path = f"{assets_path}/{organism.name}_{i}.h5ad"
             h5ad.write_h5ad(h5ad_path)
             datasets.append(


### PR DESCRIPTION
1. Acceptance tests now use unsigned requests, which is required if you want to run them on an EC2 machine without explicit IAM permissions
2. Fixes an issue where matrices generated for builder tests fixtures sometimes contain rows with all zeros, causing the presence matrix to have a different nnz count