### PR TITLE
[builder] Absolute uris should use the default mirror

### DIFF
--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/__main__.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/__main__.py
@@ -221,16 +221,18 @@ def do_the_release(args: CensusBuildArgs) -> bool:
     parsed_url = urlparse(args.config.cellxgene_census_S3_path)
     prefix = parsed_url.path
 
+    # Absolute URIs are deprecated, but we still need to support them for legacy reasons.
+    # They should point to the default mirror location.
     release: CensusVersionDescription = {
         "release_date": None,
         "release_build": args.build_tag,
         "soma": {
-            "uri": urlcat(args.config.cellxgene_census_S3_path, args.build_tag, "soma/"),
+            "uri": urlcat(args.config.cellxgene_census_default_mirror_S3_path, args.build_tag, "soma/"),
             "relative_uri": urlcat(prefix, args.build_tag, "soma/"),
             "s3_region": "us-west-2",
         },
         "h5ads": {
-            "uri": urlcat(args.config.cellxgene_census_S3_path, args.build_tag, "h5ads/"),
+            "uri": urlcat(args.config.cellxgene_census_default_mirror_S3_path, args.build_tag, "h5ads/"),
             "relative_uri": urlcat(prefix, args.build_tag, "h5ads/"),
             "s3_region": "us-west-2",
         },

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_state.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_state.py
@@ -37,6 +37,9 @@ class CensusBuildConfig:
     # Primary bucket location
     cellxgene_census_S3_path: str = field(default="s3://cellxgene-data-public/cell-census")
     #
+    # Default mirror bucket location. Used for building legacy absolute URIs.
+    cellxgene_census_default_mirror_S3_path: str = field(default="s3://cellxgene-census-public-us-west-2/cell-census")
+    #
     # Replica bucket location
     cellxgene_census_S3_replica_path: str = field(default=None)
     logs_S3_path: str = field(default="s3://cellxgene-data-public-logs/builder")

--- a/tools/cellxgene_census_builder/tests/test_workflow_steps.py
+++ b/tools/cellxgene_census_builder/tests/test_workflow_steps.py
@@ -76,6 +76,7 @@ def test_do_the_release(tmp_path: pathlib.Path, dryrun: bool) -> None:
         config=CensusBuildConfig(
             build_tag=build_tag,
             cellxgene_census_S3_path=TEST_BUCKET_PATH,
+            cellxgene_census_default_mirror_S3_path=TEST_BUCKET_PATH,
             dryrun=dryrun,
         ),
     )


### PR DESCRIPTION
Mirror resolution is done via the `mirrors.json` file on newer versions of the census API, but for legacy reasons we're still supporting absolute URIs. These don't support mirrors and should just point to the default one.

Also note that the h5ad functions also do not support mirroring, and still read from the absolute uris. This was done on purpose due to the original intent of deprecating those h5ads locations, but we should probably update them now. I can submit a separate PR for it.