### PR TITLE
Fix tests that had the mirror name hardcoded

### DIFF
--- a/api/python/cellxgene_census/tests/test_open.py
+++ b/api/python/cellxgene_census/tests/test_open.py
@@ -198,12 +198,12 @@ def test_open_soma_defaults_to_stable(requests_mock: rm.Mocker) -> None:
             "release_date": "2022-10-30",
             "release_build": "2022-10-01",
             "soma": {
-                "uri": "s3://cellxgene-data-public/cell-census/2022-10-01/soma/",
+                "uri": "s3://cellxgene-census-public-us-west-2/cell-census/2022-10-01/soma/",
                 "relative_uri": "/cell-census/2022-10-01/soma/",
                 "s3_region": "us-west-2",
             },
             "h5ads": {
-                "uri": "s3://cellxgene-data-public/cell-census/2022-10-01/h5ads/",
+                "uri": "s3://cellxgene-census-public-us-west-2/cell-census/2022-10-01/h5ads/",
                 "relative_uri": "/cell-census/2022-10-01/soma/",
                 "s3_region": "us-west-2",
             },
@@ -214,7 +214,11 @@ def test_open_soma_defaults_to_stable(requests_mock: rm.Mocker) -> None:
     with patch("cellxgene_census._open._open_soma") as m:
         cellxgene_census.open_soma()
         m.assert_called_once_with(
-            {"uri": "s3://cellxgene-data-public/cell-census/2022-10-01/soma/", "region": "us-west-2", "provider": "S3"},
+            {
+                "uri": "s3://cellxgene-census-public-us-west-2/cell-census/2022-10-01/soma/",
+                "region": "us-west-2",
+                "provider": "S3",
+            },
             None,
         )
 

--- a/api/r/cellxgene.census/tests/testthat/helper-open_soma.R
+++ b/api/r/cellxgene.census/tests/testthat/helper-open_soma.R
@@ -22,7 +22,7 @@ open_soma_latest_for_test <- function(...) {
 # is withdrawn for any reason.
 KNOWN_CENSUS_VERSION <- "2023-05-15" # an LTS version
 KNOWN_CENSUS_URI <- paste0(
-  "s3://cellxgene-data-public/cell-census/",
+  "s3://cellxgene-census-public-us-west-2/cell-census/",
   KNOWN_CENSUS_VERSION,
   "/soma/"
 )

--- a/api/r/cellxgene.census/tests/testthat/test-open.R
+++ b/api/r/cellxgene.census/tests/testthat/test-open.R
@@ -3,7 +3,7 @@ test_that("open_soma", {
   on.exit(coll$close(), add = TRUE)
   expect_true(coll$is_open())
   expect_equal(coll$mode(), "READ")
-  expect_true(startsWith(coll$uri, "s3://cellxgene-data-public/cell-census/"))
+  expect_true(startsWith(coll$uri, "s3://cellxgene-census-public-us-west-2/cell-census/"))
   expect_true(coll$exists())
   expect_true(coll$get("census_data")$get("homo_sapiens")$exists())
 })

--- a/tools/cellxgene_census_builder/tests/test_release_manifest.py
+++ b/tools/cellxgene_census_builder/tests/test_release_manifest.py
@@ -24,8 +24,11 @@ TEST_CENSUS_BASE_PREFIX = "/path/"
 
 @pytest.mark.live_corpus
 def test_get_release_manifest() -> None:
-    census_base_url = CensusBuildConfig().cellxgene_census_S3_path
-    release_manifest = get_release_manifest(census_base_url, s3_anon=True)
+    # The release manifest is read from the primary bucket.
+    census_primary_bucket_base_location = CensusBuildConfig().cellxgene_census_S3_path
+    # The base (absolute) URI should be the default mirror.
+    census_base_url = CensusBuildConfig().cellxgene_census_default_mirror_S3_path
+    release_manifest = get_release_manifest(census_primary_bucket_base_location, s3_anon=True)
     assert len(release_manifest) > 0
     assert "latest" in release_manifest
     assert release_manifest["latest"] in release_manifest


### PR DESCRIPTION
Some tests had the `cellxgene-data-public` mirror hardcoded and stopped working after the migration. 