### PR TITLE
[builder] Fix builder release manifest validation to not check for absolute uri

### DIFF
--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/release_manifest.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/release_manifest.py
@@ -126,19 +126,24 @@ def _validate_release_info(
     prefix = parsed_url.path
 
     expected_soma_locator = {
-        "uri": urlcat(census_base_url, rls_tag, "soma/"),
         "relative_uri": urlcat(prefix, rls_tag, "soma/"),
         "s3_region": CENSUS_AWS_REGION,
     }
     expected_h5ads_locator = {
-        "uri": urlcat(census_base_url, rls_tag, "h5ads/"),
         "relative_uri": urlcat(prefix, rls_tag, "h5ads/"),
         "s3_region": CENSUS_AWS_REGION,
     }
 
-    if rls_info["soma"] != expected_soma_locator:
+    # uri (a.k.a. absolute_uri) is legacy and depends on a specific location. To simplify
+    # the code, we can skip this check.
+    rls_info_soma = dict(rls_info["soma"])
+    del rls_info_soma["uri"]
+    rls_info_h5ads = dict(rls_info["h5ads"])
+    del rls_info_h5ads["uri"]
+
+    if rls_info_soma != expected_soma_locator:
         raise ValueError(f"Release record for {rls_tag} contained unexpected SOMA locator")
-    if rls_info["h5ads"] != expected_h5ads_locator:
+    if rls_info_h5ads != expected_h5ads_locator:
         raise ValueError(f"Release record for {rls_tag} contained unexpected H5AD locator")
 
 


### PR DESCRIPTION
Fixes an issue introduced by the switch to the new bucket in the `uri` field. To keep the code simple, I removed the explicit `uri` check in the manifest validation - I think this is acceptable since that is now a legacy field. Alternatively, we can pass the "default mirror bucket" all the way to that function, but that will make the code more complex. @bkmartinjr let me know what you think.