### PR TITLE
[python] upgrade to tiledbsoma and add obsm to get_anndata

### DIFF
--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -31,7 +31,7 @@ dependencies= [
     # NOTE: the tiledbsoma version must be >= to the version used in the Census builder, to
     # ensure that the assets are readable (tiledbsoma supports backward compatible reading).
     # Make sure this version does not fall behind the builder's tiledbsoma version.
-    "tiledbsoma~=1.5.1",
+    "tiledbsoma~=1.6.0",
     "anndata",
     "numpy>=1.21,<1.25",  # numpy is constrained by numba and the old pip solver
     "requests",

--- a/api/python/cellxgene_census/src/cellxgene_census/_get_anndata.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/_get_anndata.py
@@ -21,12 +21,12 @@ def get_anndata(
     measurement_name: str = "RNA",
     X_name: str = "raw",
     X_layers: Optional[Sequence[str]] = (),
+    obsm_layers: Optional[Sequence[str]] = (),
     obs_value_filter: Optional[str] = None,
     obs_coords: Optional[SparseDFCoord] = None,
     var_value_filter: Optional[str] = None,
     var_coords: Optional[SparseDFCoord] = None,
     column_names: Optional[soma.AxisColumnNames] = None,
-    obsm_layers: Optional[Sequence[str]] = (),
 ) -> anndata.AnnData:
     """
     Convience wrapper around ``soma.Experiment`` query, to build and execute a query,

--- a/api/python/cellxgene_census/src/cellxgene_census/_get_anndata.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/_get_anndata.py
@@ -26,6 +26,7 @@ def get_anndata(
     var_value_filter: Optional[str] = None,
     var_coords: Optional[SparseDFCoord] = None,
     column_names: Optional[soma.AxisColumnNames] = None,
+    obsm_layers: Optional[Sequence[str]] = (),
 ) -> anndata.AnnData:
     """
     Convience wrapper around ``soma.Experiment`` query, to build and execute a query,
@@ -56,6 +57,8 @@ def get_anndata(
             May be an ``int``, a list of ``int``, or a slice. The default, ``None``, selects all.
         column_names:
             Columns to fetch for ``obs`` and ``var`` dataframes.
+        obsm_layers:
+            Additional obsm layers to read and return in the ``obsm`` slot.
 
     Returns:
         An :class:`anndata.AnnData` object containing the census slice.
@@ -78,4 +81,4 @@ def get_anndata(
         obs_query=soma.AxisQuery(value_filter=obs_value_filter, coords=obs_coords),
         var_query=soma.AxisQuery(value_filter=var_value_filter, coords=var_coords),
     ) as query:
-        return query.to_anndata(X_name=X_name, column_names=column_names, X_layers=X_layers)
+        return query.to_anndata(X_name=X_name, column_names=column_names, X_layers=X_layers, obsm_layers=obsm_layers)

--- a/api/python/cellxgene_census/tests/test_get_anndata.py
+++ b/api/python/cellxgene_census/tests/test_get_anndata.py
@@ -147,3 +147,42 @@ def test_get_anndata_wrong_layer_names(census: soma.Collection) -> None:
             )
 
             assert raise_info.value.args[0] == "Unknown X layer name"
+
+
+@pytest.mark.skip(reason="Enable when obsm is available in a live Census distribution.")
+@pytest.mark.live_corpus
+@pytest.mark.parametrize("obsm_layer", ["scvi", "geneformer"])
+def test_get_anndata_obsm_one_layer(census: soma.Collection, obsm_layer: str) -> None:
+    with census:
+        ad = cellxgene_census.get_anndata(
+            census,
+            organism="Homo sapiens",
+            X_name="raw",
+            obs_coords=slice(100),
+            var_coords=slice(200),
+            obsm_layers=[obsm_layer],
+        )
+
+    assert len(ad.obsm.keys()) == 1
+    assert obsm_layer in ad.obsm.keys()
+    assert ad.obsm[obsm_layer].shape[0] == 100
+
+
+@pytest.mark.skip(reason="Enable when obsm is available in a live Census distribution.")
+@pytest.mark.live_corpus
+@pytest.mark.parametrize("obsm_layers", [["scvi", "geneformer"]])
+def test_get_anndata_obsm_two_layers(census: soma.Collection, obsm_layers: List[str]) -> None:
+    with census:
+        ad = cellxgene_census.get_anndata(
+            census,
+            organism="Homo sapiens",
+            X_name="raw",
+            obs_coords=slice(100),
+            var_coords=slice(200),
+            obsm_layers=obsm_layers,
+        )
+
+    assert len(ad.obsm.keys()) == 2
+    for obsm_layer in obsm_layers:
+        assert obsm_layer in ad.obsm.keys()
+        assert ad.obsm[obsm_layer].shape[0] == 100


### PR DESCRIPTION
Resolves #874 

Note: currently there are no unit tests that do not rely on the live corpus for data layers. Since `obsm` isn't yet available in any live Census distributions, the unit tests are marked as skipped.