### PR TITLE
[builder] Update release cleanup code to support relative URIs

### DIFF
--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/release_cleanup.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/release_cleanup.py
@@ -55,8 +55,6 @@ def remove_releases_older_than(days: int, census_base_url: str, dryrun: bool, s3
             rls_info = release_manifest[rls_tag]
             assert isinstance(rls_info, dict)
             uri = urlcat(census_base_url, rls_tag + "/")
-            assert uri == urlcat(rls_info["soma"]["uri"], "..")  # defensive assert
-            assert uri == urlcat(rls_info["h5ads"]["uri"], "..")  # defensive assert
             _perform_recursive_delete(rls_tag, uri, dryrun)
 
 


### PR DESCRIPTION
These assert do not work anymore because the absolute uri doesn't match the uri of the primary bucket anymore. I don't believe other assertions are necessary here. We could force a check that the URI matches a hardcoded pattern if we want to keep a defensive assert, but it will break again if we (e.g.) decide to change the location of the primary bucket.