### PR TITLE
[python] Geneformer WDL: pin TileDB and Census versions

### DIFF
--- a/tools/models/geneformer/Dockerfile
+++ b/tools/models/geneformer/Dockerfile
@@ -5,13 +5,18 @@
 # - our Census-Geneformer training scripts
 FROM nvcr.io/nvidia/pytorch:23.10-py3
 
-RUN apt update && apt install -y git-lfs pigz
+# Set the tiledbsoma version used to write the embeddings SparseNDArray, to ensure
+# compatibility with the Census embeddings curator
+ARG EMBEDDINGS_TILEDBSOMA_VERSION=1.4.4
+ARG GENEFORMER_VERSION=8df5dc1
+
+RUN apt update && apt install -y python3-venv git-lfs pigz
 RUN git lfs install
 ENV GIT_SSL_NO_VERIFY=true
 RUN pip install \
         transformers[torch] \
         "cellxgene_census[experimental] @ git+https://github.com/chanzuckerberg/cellxgene-census.git#subdirectory=api/python/cellxgene_census" \
-        git+https://huggingface.co/ctheodoris/Geneformer
+        git+https://huggingface.co/ctheodoris/Geneformer@${GENEFORMER_VERSION}
 RUN pip install owlready2 boto3
 
 # workaround for unknown problem blocking `import geneformer`:
@@ -23,7 +28,14 @@ RUN python3 -c 'import geneformer; import cellxgene_census; cellxgene_census.ope
 RUN mkdir /census-geneformer
 WORKDIR /census-geneformer
 # clone Geneformer separately to get LFS files
-RUN git clone --recursive https://huggingface.co/ctheodoris/Geneformer
+RUN git clone --recursive https://huggingface.co/ctheodoris/Geneformer \
+        && git -C Geneformer checkout ${GENEFORMER_VERSION}
+
+# prepare a venv with tiledbsoma ${EMBEDDINGS_TILEDBSOMA_VERSION}
+RUN python3 -m venv --system-site-packages embeddings_tiledbsoma_venv && \
+    . embeddings_tiledbsoma_venv/bin/activate && \
+    pip install tiledbsoma==${EMBEDDINGS_TILEDBSOMA_VERSION}
+
 COPY *.py .
 COPY helpers ./helpers
 COPY finetune-geneformer.config.yml .

--- a/tools/models/geneformer/README.md
+++ b/tools/models/geneformer/README.md
@@ -19,7 +19,7 @@ Preparing a tokenized training dataset with 2,500 primary cells per human cell t
 ```bash
 miniwdl-aws-submit --verbose --follow --workflow-queue miniwdl-workflow \
     wdl/prepare_datasets.wdl docker=$DOCKER_TAG \
-    N=2500 sampling_column=cell_type output_name=2500_per_cell_type \
+    census_version=2023-10-23 N=2500 sampling_column=cell_type output_name=2500_per_cell_type \
     --s3upload s3://MYBUCKET/geneformer/datasets/2500_per_cell_type/
 ```
 
@@ -28,7 +28,7 @@ And a tokenized dataset for all of Census (371GiB!):
 ```bash
 miniwdl-aws-submit --verbose --follow --workflow-queue miniwdl-workflow \
     wdl/prepare_datasets.wdl docker=$DOCKER_TAG \
-    output_name=census-2023-10-23 value_filter='is_primary_data==True or is_primary_data==False' \
+    census_version=2023-10-23 output_name=census-2023-10-23 value_filter='is_primary_data==True or is_primary_data==False' \
     --s3upload s3://MYBUCKET/geneformer/datasets/census-2023-10-23/
 ```
 

--- a/tools/models/geneformer/generate-geneformer-embeddings.py
+++ b/tools/models/geneformer/generate-geneformer-embeddings.py
@@ -26,6 +26,8 @@ def main(argv):
         import tiledb
         import tiledbsoma
 
+        logger.info(f"loaded tiledbsoma=={tiledbsoma.__version__} tiledb=={tiledb.__version__}")
+
         aws_region = "us-west-2"
         try:
             aws_region = boto3.Session().region_name

--- a/tools/models/geneformer/wdl/generate_embeddings.wdl
+++ b/tools/models/geneformer/wdl/generate_embeddings.wdl
@@ -37,9 +37,10 @@ task init_embeddings_array {
     }
 
     command <<<
+        set -euo pipefail
         # use venv with pinned, older tiledbsoma/tiledb to ensure compatibility with
         # Census embeddings curator
-        source embeddings_tiledbsoma_venv/bin/activate
+        source /census-geneformer/embeddings_tiledbsoma_venv/bin/activate
         python3 - <<'EOF'
         import tiledb
         import tiledbsoma
@@ -81,7 +82,7 @@ task generate_embeddings {
     command <<<
         set -euo pipefail
         >&2 sha256sum /census-geneformer/*.py
-        source embeddings_tiledbsoma_venv/bin/activate
+        source /census-geneformer/embeddings_tiledbsoma_venv/bin/activate
         mkdir hf
         export HF_HOME="$(pwd)/hf"
         export TMPDIR="$HF_HOME"

--- a/tools/models/geneformer/wdl/generate_embeddings.wdl
+++ b/tools/models/geneformer/wdl/generate_embeddings.wdl
@@ -37,6 +37,9 @@ task init_embeddings_array {
     }
 
     command <<<
+        # use venv with pinned, older tiledbsoma/tiledb to ensure compatibility with
+        # Census embeddings curator
+        source embeddings_tiledbsoma_venv/bin/activate
         python3 - <<'EOF'
         import tiledb
         import tiledbsoma
@@ -78,6 +81,7 @@ task generate_embeddings {
     command <<<
         set -euo pipefail
         >&2 sha256sum /census-geneformer/*.py
+        source embeddings_tiledbsoma_venv/bin/activate
         mkdir hf
         export HF_HOME="$(pwd)/hf"
         export TMPDIR="$HF_HOME"

--- a/tools/models/geneformer/wdl/prepare_datasets.wdl
+++ b/tools/models/geneformer/wdl/prepare_datasets.wdl
@@ -8,7 +8,7 @@ task prepare_census_geneformer_dataset {
         Array[String] obs_columns = ["soma_joinid", "cell_type", "cell_type_ontology_term_id", "cell_subclass", "cell_subclass_ontology_term_id"]
         Int N = 0
         String sampling_column = "cell_subclass"
-        String census_version = "latest"
+        String census_version = "stable"
 
         String docker
     }


### PR DESCRIPTION
Pin the TileDB and Census versions to ensure compatibility with embeddings curator