### PR TITLE
[builder] add user agent HTTP header to H5AD requests

### DIFF
--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_state.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_state.py
@@ -77,6 +77,9 @@ class CensusBuildConfig:
     dataset_id_blocklist_uri: str = field(
         default="https://raw.githubusercontent.com/chanzuckerberg/cellxgene-census/main/tools/cellxgene_census_builder/dataset_blocklist.txt"
     )
+    # User Agent header for all dataset requests from the datasets.cellxgene.cziscience.com route.
+    user_agent_prefix: str = field(default="census-builder-")
+    user_agent_environment: str = field(default="unknown")
     #
     # For testing convenience only
     manifest: str = field(default=None)


### PR DESCRIPTION
Changes:
* Added two configuration variables for the Builder User-Agent HTTP header:
    *  `user_agent_prefix` -- defaults to "census-builder-"
    * `user_agent_environment` - defaults to "unknown"
* Set the User-Agent HTTP header on all H5AD requests to https://datasets.cellxgene.cziscience.com/...   The user agent value will be:    `prefix-environment/version`.  For example:   `census-builder-unknown/1.9.2.dev14+gb43f4bf`

Partial solution for #928

Note to reviewers: this was manually verified as working.  Building a unit test for this is a PITA, so I biased towards landing the functionality sooner....

Remaining work: in production, setting the environment variable `CENSUS_BUILD_USER_AGENT_ENVIRONMENT="prod"` (or whatever value we want it to be).