### PR TITLE
[misc] update census test version to use 2023-12-15 LTS version

### DIFF
--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/_embedding.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/_embedding.py
@@ -65,7 +65,7 @@ def get_embedding(
 
     Args:
         census_version:
-            The Census version tag, e.g., "2023-10-23". Used to verify that the contents of
+            The Census version tag, e.g., "2023-12-15". Used to verify that the contents of
             the embedding contain embedded cells from the same Census version.
         embedding_uri:
             The URI containing the embedding data.

--- a/api/python/cellxgene_census/tests/experimental/ml/huggingface/test_geneformer.py
+++ b/api/python/cellxgene_census/tests/experimental/ml/huggingface/test_geneformer.py
@@ -15,7 +15,7 @@ except ImportError:
     pass
 
 
-CENSUS_VERSION_FOR_GENEFORMER_TESTS = "2023-10-23"
+CENSUS_VERSION_FOR_GENEFORMER_TESTS = "2023-12-15"
 
 
 @pytest.mark.experimental


### PR DESCRIPTION
Unit tests and some docstrings had an obsolete Census version, the former which caused our GHA unit tests to fail.  Updating to use the most recent LTS version.