### PR TITLE
feat: allow users to select covariates for memento

### DIFF
--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/diffexp/memento/diff_expr.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/diffexp/memento/diff_expr.py
@@ -98,7 +98,6 @@ def compute_all(
     query_filter: str,
     treatment: str,
     n_processes: int,
-    n_features: Optional[int] = None,
     covariates: Optional[List[str]] = ["dataset_id"],
 ) -> Tuple[pd.DataFrame, pstats.Stats]:
     with tiledb.open(os.path.join(cube_path, OBS_GROUPS_ARRAY), "r") as obs_groups_array:
@@ -111,7 +110,7 @@ def compute_all(
         distinct_treatment_values = obs_groups_df[treatment].nunique()
         assert distinct_treatment_values == 2, "treatment must have exactly 2 distinct values"
 
-    features = get_features(cube_path, n_features)
+    features = get_features(cube_path, None)
 
     # compute each feature group in parallel
     n_feature_groups = min(len(features), n_processes)
@@ -313,15 +312,15 @@ def de_wls(
 # Script entrypoint
 if __name__ == "__main__":
     if len(sys.argv) < 5:
-        print("Usage: python diff_expr.py <filter> <treatment> <cube_path> <n_processes> <n_features>")
+        print("Usage: python diff_expr.py <filter> <treatment> <cube_path> <n_processes> <covariates>")
         sys.exit(1)
 
-    filter_arg, treatment_arg, cube_path_arg, n_processes, n_features = sys.argv[1:6]
+    filter_arg, treatment_arg, cube_path_arg, n_processes, covariates = sys.argv[1:6]
 
     logging.getLogger().setLevel(logging.DEBUG)
 
     de_result = compute_all(
-        cube_path_arg, filter_arg, treatment_arg, int(n_processes), int(n_features) if n_features else None
+        cube_path_arg, filter_arg, treatment_arg, int(n_processes), covariates.split(",") if covariates else None
     )
 
     # Output DE result

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/diffexp/memento/diff_expr.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/diffexp/memento/diff_expr.py
@@ -110,12 +110,12 @@ def compute_all(
     query_filter: str,
     treatment: str,
     n_processes: int,
-    covariates: Optional[Tuple[str]] = None,
+    covariates: Optional[str] = None,
 ) -> Tuple[pd.DataFrame, pstats.Stats]:
     if covariates is None:
         covariates = ["dataset_id"]
     else:
-        covariates = list(covariates)
+        covariates = covariates.split(",")
     with tiledb.open(os.path.join(cube_path, OBS_GROUPS_ARRAY), "r") as obs_groups_array:
         obs_groups_df = obs_groups_array.query(cond=query_filter or None).df[:]
         if covariates:
@@ -328,7 +328,7 @@ if __name__ == "__main__":
     logging.getLogger().setLevel(logging.DEBUG)
 
     de_result = compute_all(
-        cube_path_arg, filter_arg, treatment_arg, int(n_processes), tuple(covariates.split(",")) if covariates else None
+        cube_path_arg, filter_arg, treatment_arg, int(n_processes), covariates if covariates else None
     )
 
     # Output DE result

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/diffexp/memento/diff_expr.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/diffexp/memento/diff_expr.py
@@ -72,7 +72,6 @@ def query_estimators(
         )
         estimators_df["obs_group_joinid"] = estimators_df["selected_vars_group_joinid"].astype("uint32")
         del estimators_df["selected_vars_group_joinid"]
-        print(estimators_df.dtypes)
         estimators_df = pl.DataFrame(estimators_df)
 
     estimators_df = compute_memento_estimators_from_precomputed_stats(estimators_df)
@@ -187,7 +186,6 @@ def compute_for_features(
         f"computing for feature group {feature_group_key}, n={len(features)}, {features[0]}..{features[-1]}..."
     )
     estimators = query_estimators(cube_path, obs_groups_df, features)
-    estimators = estimators.with_columns(estimators["obs_group_joinid"].cast(pl.UInt32))
     cell_counts = selected_vars_groups_df["n_obs"].values
     obs_group_joinids = selected_vars_groups_df[["obs_group_joinid"]]
 

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/diffexp/memento/diff_expr.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/diffexp/memento/diff_expr.py
@@ -110,12 +110,12 @@ def compute_all(
     query_filter: str,
     treatment: str,
     n_processes: int,
-    covariates: Optional[str] = None,
+    covariates_str: Optional[str] = None,
 ) -> Tuple[pd.DataFrame, pstats.Stats]:
-    if covariates is None:
+    if covariates_str is None:
         covariates = ["dataset_id"]
     else:
-        covariates = covariates.split(",")
+        covariates = covariates_str.split(",")
     with tiledb.open(os.path.join(cube_path, OBS_GROUPS_ARRAY), "r") as obs_groups_array:
         obs_groups_df = obs_groups_array.query(cond=query_filter or None).df[:]
         if covariates:

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/diffexp/memento/diff_expr.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/diffexp/memento/diff_expr.py
@@ -110,9 +110,12 @@ def compute_all(
     query_filter: str,
     treatment: str,
     n_processes: int,
-    covariates: Optional[List[str]] = ("dataset_id",),
+    covariates: Optional[Tuple[str]] = None,
 ) -> Tuple[pd.DataFrame, pstats.Stats]:
-    covariates = list(covariates)
+    if covariates is None:
+        covariates = ["dataset_id"]
+    else:
+        covariates = list(covariates)
     with tiledb.open(os.path.join(cube_path, OBS_GROUPS_ARRAY), "r") as obs_groups_array:
         obs_groups_df = obs_groups_array.query(cond=query_filter or None).df[:]
         if covariates:

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/diffexp/memento/diff_expr.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/diffexp/memento/diff_expr.py
@@ -110,8 +110,9 @@ def compute_all(
     query_filter: str,
     treatment: str,
     n_processes: int,
-    covariates: Optional[List[str]] = ["dataset_id"],
+    covariates: Optional[List[str]] = ("dataset_id",),
 ) -> Tuple[pd.DataFrame, pstats.Stats]:
+    covariates = list(covariates)
     with tiledb.open(os.path.join(cube_path, OBS_GROUPS_ARRAY), "r") as obs_groups_array:
         obs_groups_df = obs_groups_array.query(cond=query_filter or None).df[:]
         if covariates:
@@ -321,7 +322,7 @@ if __name__ == "__main__":
     logging.getLogger().setLevel(logging.DEBUG)
 
     de_result = compute_all(
-        cube_path_arg, filter_arg, treatment_arg, int(n_processes), covariates.split(",") if covariates else None
+        cube_path_arg, filter_arg, treatment_arg, int(n_processes), tuple(covariates.split(",")) if covariates else None
     )
 
     # Output DE result

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/diffexp/memento/diff_expr.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/diffexp/memento/diff_expr.py
@@ -170,9 +170,12 @@ def compute_all(
         data = itertools.chain.from_iterable(results)  # flatten results
         stats = pstats.Stats()
 
-    results = pd.DataFrame(data, columns=["feature_id", "coef", "z", "pval"], copy=False).set_index("feature_id")
-    results.sort_values("z", ascending=False, inplace=True)
-    return results, stats
+    return (
+        pd.DataFrame(data, columns=["feature_id", "coef", "z", "pval"], copy=False)
+        .set_index("feature_id")
+        .sort_values("z", ascending=False, inplace=False),
+        stats,
+    )
 
 
 def get_features(cube_path: str, n_features: Optional[int] = None) -> List[str]:

--- a/api/python/cellxgene_census/tests/experimental/diffexp/memento/test_diff_expr.py
+++ b/api/python/cellxgene_census/tests/experimental/diffexp/memento/test_diff_expr.py
@@ -34,123 +34,123 @@ def test__setup__too_many_treatment_values__fails(estimators_df: pd.DataFrame) -
         # diff_expr.compute_hypothesis_test( ... )
 
 
-# TODO: Update test to work with load_data()
-@pytest.mark.skip("Update test to work with load_data()")
-@pytest.mark.parametrize(
-    "dim_counts", [{"feature_id": 3, "cell_type_ontology_term_id": 2, "dataset_id": 3, "assay_ontology_term_id": 2}]
-)
-def test_setup(estimators_df: pd.DataFrame) -> None:
-    cell_counts, design, mean, se_mean = diff_expr.load_data("", estimators_df, "cell_type_ontology_term_id", [])
+# # TODO: Update test to work with load_data()
+# @pytest.mark.skip("Update test to work with load_data()")
+# @pytest.mark.parametrize(
+#     "dim_counts", [{"feature_id": 3, "cell_type_ontology_term_id": 2, "dataset_id": 3, "assay_ontology_term_id": 2}]
+# )
+# def test_setup(estimators_df: pd.DataFrame) -> None:
+#     cell_counts, design, mean, se_mean = diff_expr.load_data("", estimators_df, "cell_type_ontology_term_id", [])
 
-    # Note: Uncomment below code block to retrieve new expected values, if test data changes.
-    # Manually verify before replacing expected values below!
+#     # Note: Uncomment below code block to retrieve new expected values, if test data changes.
+#     # Manually verify before replacing expected values below!
 
-    # print(list(cell_counts))
-    # print(features)
-    # print(design.to_dict(orient="records"))
-    # print(mean.to_dict(orient="records"))
-    # print(se_mean.to_dict(orient="records"))
+#     # print(list(cell_counts))
+#     # print(features)
+#     # print(design.to_dict(orient="records"))
+#     # print(mean.to_dict(orient="records"))
+#     # print(se_mean.to_dict(orient="records"))
 
-    assert list(cell_counts) == [1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31, 34]
-    assert design.to_dict(orient="records") == [
-        {
-            "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 0,
-            "dataset_id_dataset_id_b": 0,
-            "dataset_id_dataset_id_c": 0,
-            "assay_ontology_term_id_assay_ontology_term_id_b": 0,
-        },
-        {
-            "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 0,
-            "dataset_id_dataset_id_b": 0,
-            "dataset_id_dataset_id_c": 0,
-            "assay_ontology_term_id_assay_ontology_term_id_b": 1,
-        },
-        {
-            "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 0,
-            "dataset_id_dataset_id_b": 1,
-            "dataset_id_dataset_id_c": 0,
-            "assay_ontology_term_id_assay_ontology_term_id_b": 0,
-        },
-        {
-            "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 0,
-            "dataset_id_dataset_id_b": 1,
-            "dataset_id_dataset_id_c": 0,
-            "assay_ontology_term_id_assay_ontology_term_id_b": 1,
-        },
-        {
-            "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 0,
-            "dataset_id_dataset_id_b": 0,
-            "dataset_id_dataset_id_c": 1,
-            "assay_ontology_term_id_assay_ontology_term_id_b": 0,
-        },
-        {
-            "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 0,
-            "dataset_id_dataset_id_b": 0,
-            "dataset_id_dataset_id_c": 1,
-            "assay_ontology_term_id_assay_ontology_term_id_b": 1,
-        },
-        {
-            "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 1,
-            "dataset_id_dataset_id_b": 0,
-            "dataset_id_dataset_id_c": 0,
-            "assay_ontology_term_id_assay_ontology_term_id_b": 0,
-        },
-        {
-            "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 1,
-            "dataset_id_dataset_id_b": 0,
-            "dataset_id_dataset_id_c": 0,
-            "assay_ontology_term_id_assay_ontology_term_id_b": 1,
-        },
-        {
-            "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 1,
-            "dataset_id_dataset_id_b": 1,
-            "dataset_id_dataset_id_c": 0,
-            "assay_ontology_term_id_assay_ontology_term_id_b": 0,
-        },
-        {
-            "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 1,
-            "dataset_id_dataset_id_b": 1,
-            "dataset_id_dataset_id_c": 0,
-            "assay_ontology_term_id_assay_ontology_term_id_b": 1,
-        },
-        {
-            "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 1,
-            "dataset_id_dataset_id_b": 0,
-            "dataset_id_dataset_id_c": 1,
-            "assay_ontology_term_id_assay_ontology_term_id_b": 0,
-        },
-        {
-            "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 1,
-            "dataset_id_dataset_id_b": 0,
-            "dataset_id_dataset_id_c": 1,
-            "assay_ontology_term_id_assay_ontology_term_id_b": 1,
-        },
-    ]
-    assert mean.to_dict(orient="records") == [
-        {"feature_id_a": 2.0, "feature_id_b": 4.0, "feature_id_c": 6.0},
-        {"feature_id_a": 8.0, "feature_id_b": 10.0, "feature_id_c": 12.0},
-        {"feature_id_a": 14.0, "feature_id_b": 16.0, "feature_id_c": 18.0},
-        {"feature_id_a": 20.0, "feature_id_b": 22.0, "feature_id_c": 24.0},
-        {"feature_id_a": 26.0, "feature_id_b": 28.0, "feature_id_c": 30.0},
-        {"feature_id_a": 32.0, "feature_id_b": 34.0, "feature_id_c": 36.0},
-        {"feature_id_a": 38.0, "feature_id_b": 40.0, "feature_id_c": 42.0},
-        {"feature_id_a": 44.0, "feature_id_b": 46.0, "feature_id_c": 48.0},
-        {"feature_id_a": 50.0, "feature_id_b": 52.0, "feature_id_c": 54.0},
-        {"feature_id_a": 56.0, "feature_id_b": 58.0, "feature_id_c": 60.0},
-        {"feature_id_a": 62.0, "feature_id_b": 64.0, "feature_id_c": 66.0},
-        {"feature_id_a": 68.0, "feature_id_b": 70.0, "feature_id_c": 72.0},
-    ]
-    assert se_mean.to_dict(orient="records") == [
-        {"feature_id_a": 3.0, "feature_id_b": 6.0, "feature_id_c": 9.0},
-        {"feature_id_a": 12.0, "feature_id_b": 15.0, "feature_id_c": 18.0},
-        {"feature_id_a": 21.0, "feature_id_b": 24.0, "feature_id_c": 27.0},
-        {"feature_id_a": 30.0, "feature_id_b": 33.0, "feature_id_c": 36.0},
-        {"feature_id_a": 39.0, "feature_id_b": 42.0, "feature_id_c": 45.0},
-        {"feature_id_a": 48.0, "feature_id_b": 51.0, "feature_id_c": 54.0},
-        {"feature_id_a": 57.0, "feature_id_b": 60.0, "feature_id_c": 63.0},
-        {"feature_id_a": 66.0, "feature_id_b": 69.0, "feature_id_c": 72.0},
-        {"feature_id_a": 75.0, "feature_id_b": 78.0, "feature_id_c": 81.0},
-        {"feature_id_a": 84.0, "feature_id_b": 87.0, "feature_id_c": 90.0},
-        {"feature_id_a": 93.0, "feature_id_b": 96.0, "feature_id_c": 99.0},
-        {"feature_id_a": 102.0, "feature_id_b": 105.0, "feature_id_c": 108.0},
-    ]
+#     assert list(cell_counts) == [1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31, 34]
+#     assert design.to_dict(orient="records") == [
+#         {
+#             "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 0,
+#             "dataset_id_dataset_id_b": 0,
+#             "dataset_id_dataset_id_c": 0,
+#             "assay_ontology_term_id_assay_ontology_term_id_b": 0,
+#         },
+#         {
+#             "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 0,
+#             "dataset_id_dataset_id_b": 0,
+#             "dataset_id_dataset_id_c": 0,
+#             "assay_ontology_term_id_assay_ontology_term_id_b": 1,
+#         },
+#         {
+#             "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 0,
+#             "dataset_id_dataset_id_b": 1,
+#             "dataset_id_dataset_id_c": 0,
+#             "assay_ontology_term_id_assay_ontology_term_id_b": 0,
+#         },
+#         {
+#             "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 0,
+#             "dataset_id_dataset_id_b": 1,
+#             "dataset_id_dataset_id_c": 0,
+#             "assay_ontology_term_id_assay_ontology_term_id_b": 1,
+#         },
+#         {
+#             "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 0,
+#             "dataset_id_dataset_id_b": 0,
+#             "dataset_id_dataset_id_c": 1,
+#             "assay_ontology_term_id_assay_ontology_term_id_b": 0,
+#         },
+#         {
+#             "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 0,
+#             "dataset_id_dataset_id_b": 0,
+#             "dataset_id_dataset_id_c": 1,
+#             "assay_ontology_term_id_assay_ontology_term_id_b": 1,
+#         },
+#         {
+#             "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 1,
+#             "dataset_id_dataset_id_b": 0,
+#             "dataset_id_dataset_id_c": 0,
+#             "assay_ontology_term_id_assay_ontology_term_id_b": 0,
+#         },
+#         {
+#             "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 1,
+#             "dataset_id_dataset_id_b": 0,
+#             "dataset_id_dataset_id_c": 0,
+#             "assay_ontology_term_id_assay_ontology_term_id_b": 1,
+#         },
+#         {
+#             "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 1,
+#             "dataset_id_dataset_id_b": 1,
+#             "dataset_id_dataset_id_c": 0,
+#             "assay_ontology_term_id_assay_ontology_term_id_b": 0,
+#         },
+#         {
+#             "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 1,
+#             "dataset_id_dataset_id_b": 1,
+#             "dataset_id_dataset_id_c": 0,
+#             "assay_ontology_term_id_assay_ontology_term_id_b": 1,
+#         },
+#         {
+#             "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 1,
+#             "dataset_id_dataset_id_b": 0,
+#             "dataset_id_dataset_id_c": 1,
+#             "assay_ontology_term_id_assay_ontology_term_id_b": 0,
+#         },
+#         {
+#             "cell_type_ontology_term_id_cell_type_ontology_term_id_b": 1,
+#             "dataset_id_dataset_id_b": 0,
+#             "dataset_id_dataset_id_c": 1,
+#             "assay_ontology_term_id_assay_ontology_term_id_b": 1,
+#         },
+#     ]
+#     assert mean.to_dict(orient="records") == [
+#         {"feature_id_a": 2.0, "feature_id_b": 4.0, "feature_id_c": 6.0},
+#         {"feature_id_a": 8.0, "feature_id_b": 10.0, "feature_id_c": 12.0},
+#         {"feature_id_a": 14.0, "feature_id_b": 16.0, "feature_id_c": 18.0},
+#         {"feature_id_a": 20.0, "feature_id_b": 22.0, "feature_id_c": 24.0},
+#         {"feature_id_a": 26.0, "feature_id_b": 28.0, "feature_id_c": 30.0},
+#         {"feature_id_a": 32.0, "feature_id_b": 34.0, "feature_id_c": 36.0},
+#         {"feature_id_a": 38.0, "feature_id_b": 40.0, "feature_id_c": 42.0},
+#         {"feature_id_a": 44.0, "feature_id_b": 46.0, "feature_id_c": 48.0},
+#         {"feature_id_a": 50.0, "feature_id_b": 52.0, "feature_id_c": 54.0},
+#         {"feature_id_a": 56.0, "feature_id_b": 58.0, "feature_id_c": 60.0},
+#         {"feature_id_a": 62.0, "feature_id_b": 64.0, "feature_id_c": 66.0},
+#         {"feature_id_a": 68.0, "feature_id_b": 70.0, "feature_id_c": 72.0},
+#     ]
+#     assert se_mean.to_dict(orient="records") == [
+#         {"feature_id_a": 3.0, "feature_id_b": 6.0, "feature_id_c": 9.0},
+#         {"feature_id_a": 12.0, "feature_id_b": 15.0, "feature_id_c": 18.0},
+#         {"feature_id_a": 21.0, "feature_id_b": 24.0, "feature_id_c": 27.0},
+#         {"feature_id_a": 30.0, "feature_id_b": 33.0, "feature_id_c": 36.0},
+#         {"feature_id_a": 39.0, "feature_id_b": 42.0, "feature_id_c": 45.0},
+#         {"feature_id_a": 48.0, "feature_id_b": 51.0, "feature_id_c": 54.0},
+#         {"feature_id_a": 57.0, "feature_id_b": 60.0, "feature_id_c": 63.0},
+#         {"feature_id_a": 66.0, "feature_id_b": 69.0, "feature_id_c": 72.0},
+#         {"feature_id_a": 75.0, "feature_id_b": 78.0, "feature_id_c": 81.0},
+#         {"feature_id_a": 84.0, "feature_id_b": 87.0, "feature_id_c": 90.0},
+#         {"feature_id_a": 93.0, "feature_id_b": 96.0, "feature_id_c": 99.0},
+#         {"feature_id_a": 102.0, "feature_id_b": 105.0, "feature_id_c": 108.0},
+#     ]

--- a/api/python/cellxgene_census/tests/experimental/diffexp/memento/test_diff_expr.py
+++ b/api/python/cellxgene_census/tests/experimental/diffexp/memento/test_diff_expr.py
@@ -4,7 +4,6 @@ from typing import Dict
 import pandas as pd
 import pytest
 
-from cellxgene_census.experimental.diffexp.memento import diff_expr
 from cellxgene_census.experimental.diffexp.memento.diff_expr import CUBE_LOGICAL_DIMS_OBS
 
 

--- a/tools/models/memento/src/estimators_cube_builder/cube_builder.py
+++ b/tools/models/memento/src/estimators_cube_builder/cube_builder.py
@@ -106,12 +106,11 @@ def compute_all_estimators_for_gene(
 ) -> pd.Series[float]:
     """Computes all estimators for a given {<dim1>, ..., <dimN>, gene} group of expression values"""
 
-    size_factors_for_obs_group
     estimators: Dict[str, Any] = {}
     estimators["sum"] = gene_group_rows.soma_data.sum()
     estimators["sumsq"] = (gene_group_rows.soma_data**2).sum()
     estimators["size_factor"] = size_factors_for_obs_group.approx_size_factor.sum()
-    estimators["n_obs"] = len(gene_group_rows)
+    estimators["n_obs"] = size_factors_for_obs_group.shape[0]
 
     # order matters for estimators
     return pd.Series(data=[estimators[n] for n in ESTIMATOR_NAMES], dtype=np.float64)

--- a/tools/models/memento/src/estimators_cube_builder/cube_builder.py
+++ b/tools/models/memento/src/estimators_cube_builder/cube_builder.py
@@ -13,10 +13,8 @@ from typing import Any, Dict, List, Tuple, cast
 
 import click
 import numpy as np
-import numpy.typing as npt
 import pandas as pd
 import pyarrow as pa
-import scipy.sparse
 import tiledb
 import tiledbsoma as soma
 from somacore import AxisQuery, ExperimentAxisQuery

--- a/tools/models/memento/src/estimators_cube_builder/cube_schema.py
+++ b/tools/models/memento/src/estimators_cube_builder/cube_schema.py
@@ -36,8 +36,7 @@ CUBE_LOGICAL_DIMS = ["feature_id"] + OBS_LOGICAL_DIMS
 
 ESTIMATORS_TILEDB_DIMS = ["feature_id", "obs_group_joinid"]
 
-# ESTIMATOR_NAMES = ["nnz", "min", "max", "sum", "mean", "sem", "var", "sev", "selv"]
-ESTIMATOR_NAMES = ["mean", "sem"]
+ESTIMATOR_NAMES = ["sum", "sumsq", "size_factor", "n_obs"]
 
 
 def build_obs_categorical_values(obs_groups: pd.DataFrame) -> Dict[str, Enumeration]:

--- a/tools/models/memento/src/estimators_cube_builder/estimators.py
+++ b/tools/models/memento/src/estimators_cube_builder/estimators.py
@@ -3,7 +3,6 @@ from typing import Tuple, cast
 
 import numpy as np
 import numpy.typing as npt
-import scipy.sparse as sparse
 import scipy.stats as stats
 from numba import njit
 from numpy import random

--- a/tools/models/memento/src/estimators_cube_builder/estimators.py
+++ b/tools/models/memento/src/estimators_cube_builder/estimators.py
@@ -62,72 +62,6 @@ def unique_expr(
     return 1 / approx_sf[index].reshape(-1, 1), expr_to_return, count
 
 
-def compute_mean(X: npt.NDArray[np.float32], size_factors: npt.NDArray[np.float64]) -> np.float64:
-    """
-    Compute the mean. Approximation of the inverse-variance weighted mean.
-    +1 pseudocount.
-    """
-
-    return cast(np.float64, (X.sum() + 1) / (size_factors.sum() + 1))
-
-
-def compute_sem(X: npt.NDArray[np.float32], size_factors: npt.NDArray[np.float64]) -> np.float64:
-    """
-    Compute standard error of the mean. Approximation of the SE of inverse-variance weighted mean.
-    """
-
-    n_obs = X.shape[0]
-    return cast(np.float64, (X.std() * np.sqrt(n_obs)) / size_factors.sum())
-
-
-def compute_variance(
-    X: csc_array, q: float, size_factor: npt.NDArray[np.float64], group_name: Tuple[str, ...]
-) -> np.float64:
-    """Compute the variances."""
-
-    if X.max() < 2 or X.mean() < RELIABILITY_THRESHOLD:  # variance cannot be estimated
-        return np.float64(0)
-
-    n_obs = X.shape[0]
-    row_weight = (1 / size_factor).reshape([1, -1])
-    row_weight_sq = (1 / size_factor**2).reshape([1, -1])
-
-    mm_M1 = sparse.csc_matrix.dot(row_weight, X).ravel() / n_obs
-    mm_M2 = (
-        sparse.csc_matrix.dot(row_weight_sq, X.power(2)).ravel() / n_obs
-        - (1 - q) * sparse.csc_matrix.dot(row_weight_sq, X).ravel() / n_obs
-    )
-
-    mean = mm_M1
-    variance = mm_M2 - mm_M1**2
-
-    if variance < 0:
-        logging.debug(f"negative variance ({variance}) for group {group_name}: {X.data}")
-        variance = mean
-
-    return cast(np.float64, variance[0])
-
-
-def compute_bootstrap_variance(
-    unique_expr: npt.NDArray[np.float32],
-    bootstrap_freq: npt.NDArray[np.float64],
-    q: float,
-    n_obs: int,
-    inverse_size_factor: npt.NDArray[np.float64],
-) -> npt.NDArray[np.float64]:
-    """Compute the bootstrapped variances for a single gene expression frequencies."""
-
-    inverse_size_factor_sq = inverse_size_factor**2
-    mm_M1 = (unique_expr * bootstrap_freq * inverse_size_factor).sum(axis=0) / n_obs
-    mm_M2 = (
-        unique_expr**2 * bootstrap_freq * inverse_size_factor_sq
-        - (1 - q) * unique_expr * bootstrap_freq * inverse_size_factor_sq
-    ).sum(axis=0) / n_obs
-
-    variance = mm_M2 - mm_M1**2
-    return cast(npt.NDArray[np.float64], variance)
-
-
 @njit  # type: ignore[misc]
 def gen_multinomial(counts: npt.NDArray[np.int64], n_obs: int, num_boot: int) -> npt.NDArray[np.int64]:
     # reset numpy random generator
@@ -135,36 +69,3 @@ def gen_multinomial(counts: npt.NDArray[np.int64], n_obs: int, num_boot: int) ->
     np.random.seed(5)
 
     return random.multinomial(n_obs, counts / counts.sum(), size=num_boot).T
-
-
-def compute_sev(
-    X: csc_array,
-    q: float,
-    approx_size_factor: npt.NDArray[np.float64],
-    num_boot: int,
-    group_name: Tuple[str, ...],
-) -> Tuple[np.float64, np.float64]:
-    """Compute the standard error of the variance."""
-
-    if X.max() < 2 or X.mean() < RELIABILITY_THRESHOLD:  # variance cannot be estimated
-        return np.float64(0.0), np.float64(0.0)
-
-    n_obs = X.shape[0]
-    inv_sf, expr, counts = unique_expr(X, approx_size_factor)
-
-    gene_rvs = gen_multinomial(counts, n_obs, num_boot)
-
-    var = compute_bootstrap_variance(
-        unique_expr=expr,
-        bootstrap_freq=gene_rvs,
-        n_obs=n_obs,
-        q=q,
-        inverse_size_factor=inv_sf,
-    )
-
-    var = fill_invalid(var, group_name)
-
-    sev = np.nanstd(var)
-    selv = np.nanstd(np.log(var))
-
-    return sev, selv

--- a/tools/models/memento/src/estimators_cube_builder/migrate_schema.py
+++ b/tools/models/memento/src/estimators_cube_builder/migrate_schema.py
@@ -1,24 +1,27 @@
 import sys
 
 import tiledb
+from cube_schema import ESTIMATOR_NAMES, build_estimators_schema
 
-from cube_schema import build_estimators_schema, ESTIMATOR_NAMES
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     old_cube_uri = sys.argv[1]
     new_cube_uri = sys.argv[2]
 
+    tdb_config = tiledb.Config(
+        {
+            "py.init_buffer_bytes": 1 * 1024**3,
+        }
+    )
 
-    tdb_config = tiledb.Config({
-        "py.init_buffer_bytes": 1 * 1024 ** 3,
-    })
-
-    with tiledb.open(old_cube_uri, 'r', config=tdb_config) as old_cube:
+    with tiledb.open(old_cube_uri, "r", config=tdb_config) as old_cube:
         n_obs_groups = old_cube.schema.domain.dim(1).domain[1]
         new_schema = build_estimators_schema(n_obs_groups)
         tiledb.Array.create(new_cube_uri, new_schema, overwrite=False)
-        with tiledb.open(new_cube_uri, 'w') as new_cube:
-            for i, old_chunk in enumerate(old_cube.query(return_incomplete=True, use_arrow=True, return_arrow=True, attrs=ESTIMATOR_NAMES).df[:], start=1):
+        with tiledb.open(new_cube_uri, "w") as new_cube:
+            for i, old_chunk in enumerate(
+                old_cube.query(return_incomplete=True, use_arrow=True, return_arrow=True, attrs=ESTIMATOR_NAMES).df[:],
+                start=1,
+            ):
                 print(f"writing chunk {i}, shape={old_chunk.shape}")
                 coords = [old_chunk[dim.name].combine_chunks() for dim in new_cube.schema.domain]
                 data = {attr.name: old_chunk[attr.name].combine_chunks() for attr in new_schema}
@@ -27,8 +30,3 @@ if __name__ == '__main__':
     print("performing consolidate & vacuum...")
     tiledb.consolidate(new_cube_uri)
     tiledb.vacuum(new_cube_uri)
-
-
-
-
-


### PR DESCRIPTION
## Changes
 - Updated the cube builder to store the sum, sumsq, n_obs, and size_factors
 - Updated the diff_expr module to calculate mean and sem on the fly, performing the necessary aggregations along the user-selected covariates.
 - Removed `n_features`. All features will be selected.

## Testing
The script was run with the following params:
`"tissue_general_ontology_term_id in ['UBERON:0002048'] and cell_type_ontology_term_id in ['CL:0000786', 'CL:0000187']" cell_type_ontology_term_id ~/czi/cellxgene-census/memento-cube-2024-01-29 1 dataset_id,assay_ontology_term_id`

The results were quickly sanity checked.