### PR TITLE
[misc] fix python dependency check workflow

### DIFF
--- a/.github/workflows/py-dependency-check.yml
+++ b/.github/workflows/py-dependency-check.yml
@@ -26,6 +26,10 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
+      - name: install tooling
+        run: |
+          sudo apt-get update && sudo apt-get install jq
+
       - name: get latest release with tag
         id: latestrelease
         run: |

--- a/.github/workflows/py-dependency-check.yml
+++ b/.github/workflows/py-dependency-check.yml
@@ -27,10 +27,9 @@ jobs:
 
     steps:
       - name: install tooling
+        if: matrix.os == 'single-cell-8c64g-runner'
         run: |
-          if [ {{matrix.os}} != "macos-latest" ]; then
-            sudo apt-get update && sudo apt-get install jq
-          fi
+          sudo apt-get update && sudo apt-get install jq
 
       - name: get latest release with tag
         id: latestrelease

--- a/.github/workflows/py-dependency-check.yml
+++ b/.github/workflows/py-dependency-check.yml
@@ -29,7 +29,7 @@ jobs:
       - name: install tooling
         if: matrix.os == 'single-cell-8c64g-runner'
         run: |
-          sudo apt-get update && sudo apt-get install jq
+          sudo apt-get update && sudo apt-get install -y jq
 
       - name: get latest release with tag
         id: latestrelease

--- a/.github/workflows/py-dependency-check.yml
+++ b/.github/workflows/py-dependency-check.yml
@@ -28,7 +28,9 @@ jobs:
     steps:
       - name: install tooling
         run: |
-          sudo apt-get update && sudo apt-get install jq
+          if [ {{matrix.os}} != "macos-latest" ]; then
+            sudo apt-get update && sudo apt-get install jq
+          fi
 
       - name: get latest release with tag
         id: latestrelease


### PR DESCRIPTION
Self-hosted runners do not have the same tooling as GH hosted.  Install missing items

Important note to reviewers:  this weekly GHA will continue to fail until we ship a new release of the Census package, for two reasons:
* there was a bug in the tests at the time of the release
* the tests at the time of the release specified a (now) non-existent census version as a test dataset
Both of these will resolve when we do the next release.

This PR fixes a separate issue - the lack of certain tooling on the self-hosted Linux runners.