### PR TITLE
[misc] update to setup-python v5

### DIFF
--- a/.github/workflows/docsite-build-deploy.yml
+++ b/.github/workflows/docsite-build-deploy.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/lts-compat-check.yml
+++ b/.github/workflows/lts-compat-check.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/py-dependency-check.yml
+++ b/.github/workflows/py-dependency-check.yml
@@ -51,7 +51,7 @@ jobs:
           ref: ${{ steps.latestrelease.outputs.releasetag }}
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/py-formatting.yml
+++ b/.github/workflows/py-formatting.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: check backend


### PR DESCRIPTION
This PR resolves the warnings about using an obsolete version of setup-python (node16 deprecation) in various GHA workflows.
