### PR TITLE
feat: 'native cell' -> 'unknown' on geneformer label_blocklist -- DO NOT MERGE (yet)

### DIFF
--- a/tools/models/geneformer/finetune-geneformer.config.yml
+++ b/tools/models/geneformer/finetune-geneformer.config.yml
@@ -2,7 +2,7 @@
 label_feature: cell_subclass
 # Specific labels to exclude from training and evaluation
 label_blocklist:
-  - native cell
+  - unknown
 # Also exclude labels with too few examples
 label_min_examples: 10
 # Fraction of the input Dataset to hold out for evaluation


### PR DESCRIPTION
Fixes #1019

Schema 5.0 will use an updated ontology that does not include `CL:0000003 - native cell`. We will accept instead `"unknown"` for the `cell_type_ontology_term_id`, and accordingly we will annotate `cell_type` (label) as `"unknown"`.

This should (probably) be merged once we migrate. @mlin let me know if you foresee any issues.