### PR TITLE
[docs] Add embeddings API to docs

### DIFF
--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -62,3 +62,12 @@ Experimental: Processing
     cellxgene_census.experimental.pp.get_highly_variable_genes
     cellxgene_census.experimental.pp.highly_variable_genes
     cellxgene_census.experimental.pp.mean_variance
+
+Experimental: Embeddings
+--------------------------------
+.. autosummary::
+    :toctree: _autosummary/
+    :nosignatures:
+
+    cellxgene_census.experimental.get_embedding
+    cellxgene_census.experimental.get_embedding_metadata


### PR DESCRIPTION
Let me know if this is a welcome change! Adds the model embedding API to the docs (`get_embedding` and `get_embedding_metadata`).