### PR TITLE
[builder] thread usage config for main thread

### DIFF
--- a/tools/cellxgene_census_builder/entrypoint.sh
+++ b/tools/cellxgene_census_builder/entrypoint.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# These configure thread allocation for BLAS, OpenMP, etc. We don't use these
+# packages, but they will allocate a large number of threads at startup (usually
+# one thread per host CPU). Turn down the allocation which gets excessive in
+# high-CPU hosts, such as those used to build the Census.
+export OMP_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export VECLIB_MAXIMUM_THREADS=1
+
 # Log tiledbsoma package versions
 python3 -c 'import tiledbsoma; tiledbsoma.show_package_versions()'
 


### PR DESCRIPTION
The builder lacked thread allocation config for the main thread, resulting in unused/excessive thread allocation in the main thread.  This is a companion to `env_var_init()`, which sets the config for all child (worker) processes.
