### PR TITLE
[builder] fix incorrect filtering of tissue type

### DIFF
--- a/docs/cellxgene_census_schema.md
+++ b/docs/cellxgene_census_schema.md
@@ -263,7 +263,7 @@ Per the CELLxGENE dataset schema, [all RNA assays MUST include UMI or read count
 
 #### Sample types
 
-Only observations (cells) from primary tissue MUST be included in the Census. Thus observations with a [`tissue_ontology_term_id`](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md#tissue_ontology_term_id) value of  "ontology\_term\_id (organoid)" or "ontology\_term\_id (cell line)" MUST NOT be included.
+Only observations (cells) from primary tissue MUST be included in the Census. Thus, ONLY those observations with a [`tissue_type`](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md#tissue_type) value equal to "tissue" MUST be included; other values of `tissue_type` MUST NOT be included.
 
 #### Repeated data
 

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/anndata.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/anndata.py
@@ -232,7 +232,7 @@ class AnnDataProxy:
 
 
 # The minimum columns required to be able to filter an H5AD.  See `make_anndata_cell_filter` for details.
-CXG_OBS_COLUMNS_MINIMUM_READ = ("assay_ontology_term_id", "organism_ontology_term_id", "tissue_ontology_term_id")
+CXG_OBS_COLUMNS_MINIMUM_READ = ("assay_ontology_term_id", "organism_ontology_term_id", "tissue_type")
 CXG_VAR_COLUMNS_MINIMUM_READ = ("feature_biotype", "feature_reference")
 
 
@@ -299,11 +299,7 @@ def make_anndata_cell_filter(filter_spec: AnnDataFilterSpec) -> AnnDataFilterFun
         #
         # Filter cells per Census schema
         #
-        obs_mask = ~(  # noqa: E712
-            ad.obs.tissue_ontology_term_id.str.endswith(" (organoid)")
-            | ad.obs.tissue_ontology_term_id.str.endswith(" (cell culture)")
-        )
-
+        obs_mask = ad.obs.tissue_type == "tissue"
         if organism_ontology_term_id is not None:
             obs_mask = obs_mask & (ad.obs.organism_ontology_term_id == organism_ontology_term_id)
         if assay_ontology_term_ids is not None:

--- a/tools/cellxgene_census_builder/tests/anndata/conftest.py
+++ b/tools/cellxgene_census_builder/tests/anndata/conftest.py
@@ -102,8 +102,8 @@ def h5ad_simple(tmp_path: pathlib.Path) -> str:
 @pytest.fixture
 def h5ad_with_organoids_and_cell_culture(tmp_path: pathlib.Path) -> str:
     adata = get_anndata(ORGANISMS[0], no_zero_counts=True)
-    adata.obs.at["1", "tissue_ontology_term_id"] = "CL:0000192 (organoid)"
-    adata.obs.at["2", "tissue_ontology_term_id"] = "CL:0000192 (cell culture)"
+    adata.obs.at["1", "tissue_type"] = "organoid"
+    adata.obs.at["2", "tissue_type"] = "cell culture"
 
     path = "with_organoids_and_cell_culture.h5ad"
     adata.write_h5ad(tmp_path / path)

--- a/tools/cellxgene_census_builder/tests/conftest.py
+++ b/tools/cellxgene_census_builder/tests/conftest.py
@@ -69,7 +69,7 @@ def get_anndata(
             "sex": "test",
             "tissue": "test",
             "organism": "test",
-            "tissue_type": "test",
+            "tissue_type": "tissue",
             "observation_joinid": "test",
         },
         index=["1", "2", "3", "4"],


### PR DESCRIPTION

Fixes #1009 

In the update to handle schema 4, the obs axis filtering for organoid and cell culture was not implemented.  This PR resolves that.

Changes:
* Obs filter on `tissue_type == "tissue"`
* Fix tests to match
* update schema doc to match