### PR TITLE
[misc] use docker buildx

### DIFF
--- a/.github/workflows/py-build.yml
+++ b/.github/workflows/py-build.yml
@@ -70,10 +70,7 @@ jobs:
           set -x
 
           for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do
-            $(dpkg --status $pkg &> /dev/null)
-            if [[ $? -eq 0 ]]; then
-              sudo apt-get remove $pkg
-            fi
+            sudo apt-get remove $pkg || echo "${pkg} not installed"
           done
 
           sudo apt-get update

--- a/.github/workflows/py-build.yml
+++ b/.github/workflows/py-build.yml
@@ -64,10 +64,10 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Install latest docker buildx
+      - name: Install up-to-date docker buildx
         run: |
-          # https://docs.docker.com/engine/install/ubuntu/
-          set -x
+          # In lieu of having docker buildx plugin installed on our base runner image,
+          # install it manually. https://docs.docker.com/engine/install/ubuntu/
 
           for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do
             sudo apt-get remove $pkg || echo "${pkg} not installed"

--- a/.github/workflows/py-build.yml
+++ b/.github/workflows/py-build.yml
@@ -75,7 +75,7 @@ jobs:
 
           sudo apt-get update
           sudo apt-get install -y ca-certificates curl
-          sudo install -y -m 0755 -d /etc/apt/keyrings
+          sudo install -m 0755 -d /etc/apt/keyrings
           sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
           sudo chmod a+r /etc/apt/keyrings/docker.asc
 

--- a/.github/workflows/py-build.yml
+++ b/.github/workflows/py-build.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Install deps
         run: |
+          sudo apt-get install -y docker-buildx-plugin
           python -m pip install -U pip setuptools build
 
       - name: Build

--- a/.github/workflows/py-build.yml
+++ b/.github/workflows/py-build.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Install deps
         run: |
-          sudo apt-get install -y docker-buildx-plugin
+          sudo apt-get update && sudo apt-get install -y docker-buildx-plugin
           python -m pip install -U pip setuptools build
 
       - name: Build package

--- a/.github/workflows/py-build.yml
+++ b/.github/workflows/py-build.yml
@@ -67,8 +67,14 @@ jobs:
       - name: Install latest docker buildx
         run: |
           # https://docs.docker.com/engine/install/ubuntu/
+          set -x
 
-          for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
+          for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do
+            $(dpkg --status $pkg &> /dev/null)
+            if [[ $? -eq 0 ]]; then
+              sudo apt-get remove $pkg
+            fi
+          done
 
           sudo apt-get update
           sudo apt-get install ca-certificates curl

--- a/.github/workflows/py-build.yml
+++ b/.github/workflows/py-build.yml
@@ -26,7 +26,6 @@ jobs:
 
       - name: Install deps
         run: |
-          sudo apt-get install -y docker-buildx-plugin
           python -m pip install -U pip setuptools build
 
       - name: Build
@@ -67,6 +66,7 @@ jobs:
 
       - name: Install deps
         run: |
+          sudo apt-get install -y docker-buildx-plugin
           python -m pip install -U pip setuptools build
 
       - name: Build package

--- a/.github/workflows/py-build.yml
+++ b/.github/workflows/py-build.yml
@@ -74,8 +74,8 @@ jobs:
           done
 
           sudo apt-get update
-          sudo apt-get install ca-certificates curl
-          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo apt-get install -y ca-certificates curl
+          sudo install -y -m 0755 -d /etc/apt/keyrings
           sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
           sudo chmod a+r /etc/apt/keyrings/docker.asc
 
@@ -86,7 +86,7 @@ jobs:
             sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
 
-          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
       - name: Install python deps
         run: |

--- a/.github/workflows/py-build.yml
+++ b/.github/workflows/py-build.yml
@@ -64,9 +64,29 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Install deps
+      - name: Install latest docker buildx
         run: |
-          sudo apt-get update && sudo apt-get install -y docker-buildx-plugin
+          # https://docs.docker.com/engine/install/ubuntu/
+
+          for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
+
+          sudo apt-get update
+          sudo apt-get install ca-certificates curl
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+          # Add the repository to Apt sources:
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+
+          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+      - name: Install python deps
+        run: |
           python -m pip install -U pip setuptools build
 
       - name: Build package


### PR DESCRIPTION
Fixes #985 

Until our GH runners have docker buildx installed, do so manually.