### PR TITLE
[misc] update to latest pre-commit GH action

### DIFF
--- a/.github/workflows/py-formatting.yml
+++ b/.github/workflows/py-formatting.yml
@@ -17,5 +17,5 @@ jobs:
         with:
           python-version: "3.10"
       - name: check backend
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1
 


### PR DESCRIPTION
Update to latest pre-commit github action, removing a warning during CI re: node version obsolescence
