### PR TITLE
[misc] Prepare for 1.12.0 release

### DIFF
--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -31,6 +31,7 @@ dependencies= [
     # NOTE: the tiledbsoma version must be >= to the version used in the Census builder, to
     # ensure that the assets are readable (tiledbsoma supports backward compatible reading).
     # Make sure this version does not fall behind the builder's tiledbsoma version.
+    # TODO: When ready to release 1.12.0 update tiledbsoma version to 1.9.0 and delete this temporary comment 
     "tiledbsoma~=1.8.0",
     "anndata",
     "numpy>=1.21",

--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -32,7 +32,7 @@ dependencies= [
     # ensure that the assets are readable (tiledbsoma supports backward compatible reading).
     # Make sure this version does not fall behind the builder's tiledbsoma version.
     # TODO: When ready to release 1.12.0 update tiledbsoma version to 1.9.x and delete this temporary comment 
-    "tiledbsoma~=1.9.1",
+    "tiledbsoma~=1.9.0",
     "anndata",
     "numpy>=1.21",
     "requests",

--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -31,7 +31,6 @@ dependencies= [
     # NOTE: the tiledbsoma version must be >= to the version used in the Census builder, to
     # ensure that the assets are readable (tiledbsoma supports backward compatible reading).
     # Make sure this version does not fall behind the builder's tiledbsoma version.
-    # TODO: When ready to release 1.12.0 update tiledbsoma version to 1.9.x and delete this temporary comment 
     "tiledbsoma~=1.9.1",
     "anndata",
     "numpy>=1.21",

--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -32,7 +32,7 @@ dependencies= [
     # ensure that the assets are readable (tiledbsoma supports backward compatible reading).
     # Make sure this version does not fall behind the builder's tiledbsoma version.
     # TODO: When ready to release 1.12.0 update tiledbsoma version to 1.9.x and delete this temporary comment 
-    "tiledbsoma~=1.9.0",
+    "tiledbsoma~=1.9.1",
     "anndata",
     "numpy>=1.21",
     "requests",

--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -31,8 +31,8 @@ dependencies= [
     # NOTE: the tiledbsoma version must be >= to the version used in the Census builder, to
     # ensure that the assets are readable (tiledbsoma supports backward compatible reading).
     # Make sure this version does not fall behind the builder's tiledbsoma version.
-    # TODO: When ready to release 1.12.0 update tiledbsoma version to 1.9.0 and delete this temporary comment 
-    "tiledbsoma~=1.8.0",
+    # TODO: When ready to release 1.12.0 update tiledbsoma version to 1.9.x and delete this temporary comment 
+    "tiledbsoma~=1.9.1",
     "anndata",
     "numpy>=1.21",
     "requests",

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/_embedding.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/_embedding.py
@@ -126,7 +126,7 @@ def get_embedding(
         embedding_shape = (len(obs_soma_joinids), E.shape[1])
         embedding = np.full(embedding_shape, np.NaN, dtype=np.float32, order="C")
 
-        obs_indexer = soma.tiledbsoma_build_index(obs_soma_joinids, context=E.context)
+        obs_indexer = soma.IntIndexer(obs_soma_joinids, context=E.context)
         for tbl in E.read(coords=(obs_soma_joinids,)).tables():
             obs_idx = obs_indexer.get_indexer(tbl.column("soma_dim_0").to_numpy())
             feat_idx = tbl.column("soma_dim_1").to_numpy()

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/pp/_highly_variable_genes.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/pp/_highly_variable_genes.py
@@ -89,9 +89,7 @@ def _highly_variable_genes_seurat_v3(
         n_batches = len(batch_index.cat.categories)
         n_samples = batch_index.value_counts().loc[batch_index.cat.categories.to_numpy()].to_numpy()
         if n_batches > 1:
-            batch_indexer = soma.tiledbsoma_build_index(
-                batch_index.index.to_numpy(), context=query.experiment.context
-            ).get_indexer
+            batch_indexer = soma.IntIndexer(batch_index.index.to_numpy(), context=query.experiment.context).get_indexer
             batch_codes = batch_index.cat.codes.to_numpy().astype(np.int64)
     else:
         n_batches = 1

--- a/api/r/cellxgene.census/DESCRIPTION
+++ b/api/r/cellxgene.census/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cellxgene.census
 Title: CZ CELLxGENE Discover Cell Census
-Version: 1.11.1
+Version: 1.12.0
 Authors@R: 
     person("Chan Zuckerberg Initiative Foundation", email = "soma@chanzuckerberg.com",
            role = c("aut", "cre", "cph", "fnd"))


### PR DESCRIPTION
This release of the census package is being done to include an important update for `tiledbsoma` in `1.9.0` which includes a fix to categorical columns. To ensure that this release goes smoothly, we will:

1. Run an acceptance test off `TileDB-SOMA` `main` [branch](https://github.com/single-cell-data/TileDB-SOMA/tree/main) which contains the fixes that will go into `1.9.0`. We can think of this as a _pre-release acceptance test_
2. After (1) passes and the tiledb folks officially release `tiledbsoma==1.9.0`, we will update the dependencies in this PR to point to `tiledbsoma==1.9.0` and do the official release of `cellxgene-census==1.12.0`