### PR TITLE
[python] fix hvg_vs_scanpy test

### DIFF
--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/pp/_highly_variable_genes.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/pp/_highly_variable_genes.py
@@ -206,7 +206,6 @@ def _highly_variable_genes_seurat_v3(
     median_ranked = np.ma.median(ma_ranked, axis=0).filled(np.nan)  # type: ignore[no-untyped-call]
 
     var_df = var_df.assign(
-        gene_name=var_df.index,
         highly_variable_nbatches=pd.Series(num_batches_high_var, index=var_df.index),
         highly_variable_rank=pd.Series(median_ranked, index=var_df.index),
         variances_norm=pd.Series(np.mean(norm_gene_vars, axis=0), index=var_df.index),

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/pp/_highly_variable_genes.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/pp/_highly_variable_genes.py
@@ -206,6 +206,7 @@ def _highly_variable_genes_seurat_v3(
     median_ranked = np.ma.median(ma_ranked, axis=0).filled(np.nan)  # type: ignore[no-untyped-call]
 
     var_df = var_df.assign(
+        gene_name=var_df.index,
         highly_variable_nbatches=pd.Series(num_batches_high_var, index=var_df.index),
         highly_variable_rank=pd.Series(median_ranked, index=var_df.index),
         variances_norm=pd.Series(np.mean(norm_gene_vars, axis=0), index=var_df.index),

--- a/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
+++ b/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
@@ -117,7 +117,9 @@ def test_hvg_vs_scanpy(
     scanpy_hvg.index.name = "soma_joinid"
     scanpy_hvg.index = scanpy_hvg.index.astype(int)
     assert len(scanpy_hvg) == len(hvg)
-    assert set(scanpy_hvg.drop("gene_name", axis=1).keys()) == set(hvg.keys())
+    # Since scanpy 1.10, there is an extra column in the dataframe that our hvg implementation
+    # does not support.  Drop it for comparison.
+    assert set(scanpy_hvg.drop("gene_name", axis=1, errors="ignore").keys()) == set(hvg.keys())
 
     assert (hvg.index == scanpy_hvg.index).all()
     assert np.allclose(

--- a/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
+++ b/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from typing import Any
 
 import numpy as np
@@ -16,10 +15,6 @@ from cellxgene_census.experimental.pp import (
 )
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="scanpy 1.10 requires Python 3.9+ and our hvg implementation aims to be compatible with that version.",
-)
 @pytest.mark.experimental
 @pytest.mark.live_corpus
 @pytest.mark.parametrize(
@@ -122,7 +117,7 @@ def test_hvg_vs_scanpy(
     scanpy_hvg.index.name = "soma_joinid"
     scanpy_hvg.index = scanpy_hvg.index.astype(int)
     assert len(scanpy_hvg) == len(hvg)
-    assert all(scanpy_hvg.keys() == hvg.keys())
+    assert [k for k in scanpy_hvg.keys() if k != "gene_name"] == list(hvg.keys())
 
     assert (hvg.index == scanpy_hvg.index).all()
     assert np.allclose(

--- a/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
+++ b/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import Any
 
 import numpy as np
@@ -15,6 +16,10 @@ from cellxgene_census.experimental.pp import (
 )
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="scanpy 1.10 requires Python 3.9+ and our hvg implementation aims to be compatible with that version.",
+)
 @pytest.mark.experimental
 @pytest.mark.live_corpus
 @pytest.mark.parametrize(

--- a/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
+++ b/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
@@ -117,7 +117,7 @@ def test_hvg_vs_scanpy(
     scanpy_hvg.index.name = "soma_joinid"
     scanpy_hvg.index = scanpy_hvg.index.astype(int)
     assert len(scanpy_hvg) == len(hvg)
-    assert set(scanpy_hvg.drop("gene_name").keys()) == set(hvg.keys())
+    assert set(scanpy_hvg.drop("gene_name", axis=1).keys()) == set(hvg.keys())
 
     assert (hvg.index == scanpy_hvg.index).all()
     assert np.allclose(

--- a/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
+++ b/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
@@ -117,7 +117,7 @@ def test_hvg_vs_scanpy(
     scanpy_hvg.index.name = "soma_joinid"
     scanpy_hvg.index = scanpy_hvg.index.astype(int)
     assert len(scanpy_hvg) == len(hvg)
-    assert [k for k in scanpy_hvg.keys() if k != "gene_name"] == list(hvg.keys())
+    assert set(scanpy_hvg.drop("gene_name").keys()) == set(hvg.keys())
 
     assert (hvg.index == scanpy_hvg.index).all()
     assert np.allclose(


### PR DESCRIPTION
Due to [this change](https://github.com/scverse/scanpy/commit/82f84129ed895dfdded3111b98aa4dc2ae5d4887#diff-a3319950a357c8d24de0f78d7e64852aa3c8a5b59d3a633e960d088c86528f53R137) in Scanpy's implementation, there is now a new `gene_name` field that gets added to the returned dataframe. This PR adds the same field to our implementation.