### PR TITLE
[misc] turn off fast-fail for weekly CI checks

### DIFF
--- a/.github/workflows/lts-compat-check.yml
+++ b/.github/workflows/lts-compat-check.yml
@@ -10,6 +10,7 @@ jobs:
     name: Python LTS compatibility check
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.11"]

--- a/.github/workflows/py-dependency-check.yml
+++ b/.github/workflows/py-dependency-check.yml
@@ -19,6 +19,7 @@ jobs:
     name: python-dependency-check
 
     strategy:
+      fail-fast: false  # don't fail-fast, as errors are often specific to a single cell in the matrix
       matrix:
         os: [single-cell-8c64g-runner, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]

--- a/.github/workflows/r-dependency-check.yml
+++ b/.github/workflows/r-dependency-check.yml
@@ -13,6 +13,7 @@ jobs:
     name: r-dependency-check
 
     strategy:
+      fail-fast: false  # don't fail-fast, as errors are often specific to a single cell in the matrix
       matrix:
         os: [ubuntu-22.04, macos-latest]
 


### PR DESCRIPTION
The weekly checks that explore the full matrix of version/census build/etc. had GHA fast-fail enabled.  For these periodic checks, it is better to not fast-fail, and see which pats of the test matrix work and which are in error.  They are not run during the normal dev cycle, so there is little downside, and this will help diagnose actual issues faster.
