### PR TITLE
[builder] cleanup chore

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: (^doc/)|(.*/venv/)
 default_stages: [commit]
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.2.2
+    rev: v0.3.5
     hooks:
       - id: ruff
         name: ruff-cellxgene-census
@@ -36,7 +36,7 @@ repos:
         args: ["--config=./api/python/notebooks/pyproject.toml"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: mypy
         name: mypy-cellxgene-census

--- a/api/python/cellxgene_census/src/cellxgene_census/_get_anndata.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/_get_anndata.py
@@ -6,6 +6,7 @@
 
 Methods to retrieve slices of the census as AnnData objects.
 """
+
 from typing import Optional, Sequence
 
 import anndata

--- a/api/python/cellxgene_census/src/cellxgene_census/_open.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/_open.py
@@ -6,6 +6,7 @@
 
 Contains methods to open publicly hosted versions of Census object and access its source datasets.
 """
+
 import logging
 import os.path
 import urllib.parse

--- a/api/python/cellxgene_census/src/cellxgene_census/_release_directory.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/_release_directory.py
@@ -6,6 +6,7 @@
 
 Methods to retrieve information about versions of the publicly hosted Census object.
 """
+
 import typing
 from collections import OrderedDict
 from typing import Dict, Literal, Optional, Union, cast

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/_embedding.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/_embedding.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 
 """Methods to support simplifed access to community contributed embeddings."""
+
 from __future__ import annotations
 
 import json

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/__main__.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/__main__.py
@@ -59,13 +59,6 @@ def create_args_parser() -> argparse.ArgumentParser:
     parser.add_argument("working_dir", type=str, help="Census build working directory")
     parser.add_argument("-v", "--verbose", action="count", default=0, help="Increase logging verbosity")
     parser.add_argument(
-        "-mp",
-        "--multi-process",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help="Use multiple processes",
-    )
-    parser.add_argument(
         "--max_worker_processes",
         type=int,
         default=default_config.max_worker_processes,
@@ -112,8 +105,6 @@ def create_args_parser() -> argparse.ArgumentParser:
     )
     # hidden option for testing by devs. Will process only the first 'n' datasets
     build_parser.add_argument("--test-first-n", type=int, default=0)
-    # hidden option for testing by devs. Allow for WIP testing by devs.
-    build_parser.add_argument("--disable-dirty-git-check", action=argparse.BooleanOptionalAction, default=False)
 
     # VALIDATE
     subparsers.add_parser("validate", help="Validate an existing Census build")

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/anndata.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/anndata.py
@@ -303,8 +303,7 @@ def open_anndata(
 
 
 class AnnDataFilterFunction(Protocol):
-    def __call__(self, ad: AnnDataProxy) -> AnnDataProxy:
-        ...
+    def __call__(self, ad: AnnDataProxy) -> AnnDataProxy: ...
 
 
 def make_anndata_cell_filter(filter_spec: AnnDataFilterSpec) -> AnnDataFilterFunction:

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/build_soma.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/build_soma.py
@@ -31,7 +31,7 @@ from .manifest import load_manifest
 from .mp import create_dask_client, shutdown_dask_cluster
 from .source_assets import stage_source_assets
 from .summary_cell_counts import create_census_summary_cell_counts
-from .util import get_git_commit_sha, is_git_repo_dirty
+from .util import get_git_commit_sha
 from .validate_soma import validate_consolidation, validate_soma
 
 logger = logging.getLogger(__name__)
@@ -42,10 +42,6 @@ def prepare_file_system(args: CensusBuildArgs) -> None:
     # Don't clobber an existing census build
     if args.soma_path.exists() or args.h5ads_path.exists():
         raise Exception("Census build path already exists - aborting build")
-
-    # Ensure that the git tree is clean
-    if not args.config.disable_dirty_git_check and is_git_repo_dirty():
-        raise Exception("The git repo has uncommitted changes - aborting build")
 
     # Create top-level build directories
     args.soma_path.mkdir(parents=True, exist_ok=False)

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/consolidate.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/consolidate.py
@@ -48,8 +48,7 @@ def submit_consolidate(
     vacuum: bool,
     include: Sequence[str] | None = None,
     exclude: Sequence[str] | None = None,
-) -> list[concurrent.futures.Future[str]]:
-    ...
+) -> list[concurrent.futures.Future[str]]: ...
 
 
 @overload
@@ -59,8 +58,7 @@ def submit_consolidate(
     vacuum: bool,
     include: Sequence[str] | None = None,
     exclude: Sequence[str] | None = None,
-) -> list[dask.distributed.Future]:
-    ...
+) -> list[dask.distributed.Future]: ...
 
 
 def submit_consolidate(

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/util.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/util.py
@@ -50,14 +50,3 @@ def get_git_commit_sha() -> str:
     repo = git.repo.base.Repo(search_parent_directories=True)
     hexsha: str = repo.head.object.hexsha
     return hexsha
-
-
-def is_git_repo_dirty() -> bool:
-    """Returns True if the git repo is dirty, i.e. there are uncommitted changes."""
-    import git  # Scoped import - this requires the git executable to exist on the machine
-
-    # work around https://github.com/gitpython-developers/GitPython/issues/1349
-    # by explicitly referencing git.repo.base.Repo instead of git.Repo
-    repo = git.repo.base.Repo(search_parent_directories=True)
-    is_dirty: bool = repo.is_dirty()
-    return is_dirty

--- a/tools/cellxgene_census_builder/tests/test_builder.py
+++ b/tools/cellxgene_census_builder/tests/test_builder.py
@@ -33,14 +33,12 @@ from cellxgene_census_builder.process_init import process_init
     "census_build_args",
     (
         {
-            "multi_process": False,
             "consolidate": False,
             "build_tag": "test_tag",
             "verbose": 0,
             "max_worker_processes": 1,
         },
         {
-            "multi_process": False,
             "consolidate": True,
             "build_tag": "test_tag",
             "verbose": 1,
@@ -176,7 +174,7 @@ def test_unicode_support(tmp_path: pathlib.Path) -> None:
 
 @pytest.mark.parametrize(
     "census_build_args",
-    [{"manifest": True, "verbose": 2, "build_tag": "build_tag", "multi_process": False, "max_worker_processes": 1}],
+    [{"manifest": True, "verbose": 2, "build_tag": "build_tag", "max_worker_processes": 1}],
     indirect=True,
 )
 def test_build_step1_get_source_datasets(tmp_path: pathlib.Path, census_build_args: CensusBuildArgs) -> None:

--- a/tools/cellxgene_census_builder/tests/test_main.py
+++ b/tools/cellxgene_census_builder/tests/test_main.py
@@ -9,7 +9,6 @@ def test_create_args_parser_default_build() -> None:
 
     assert args.working_dir == "."
     assert args.verbose == 0
-    assert args.multi_process is False
     assert isinstance(args.build_tag, str)
     assert args.subcommand == "build"
     assert args.validate is True
@@ -24,6 +23,5 @@ def test_create_args_parser_default_validate() -> None:
 
     assert args.working_dir == "."
     assert args.verbose == 0
-    assert args.multi_process is False
     assert isinstance(args.build_tag, str)
     assert args.subcommand == "validate"

--- a/tools/census_contrib/src/census_contrib/load.py
+++ b/tools/census_contrib/src/census_contrib/load.py
@@ -32,8 +32,7 @@ class EmbeddingIJDPipe(EmbeddingTableIterator, AbstractContextManager["Embedding
         return self
 
     @abstractproperty
-    def type(self) -> pa.DataType:
-        ...
+    def type(self) -> pa.DataType: ...
 
     @abstractproperty
     def domains(self) -> EmbeddingIJDDomains:


### PR DESCRIPTION
Changes:
* dead code removal - items missed in Dask refactor
* autoupdate and run pre-commit - minor reformatting from this
* in tests for `build()`, mock psutil.virtual_memory to reduce apparent host memory. This is to reduce occurrences of OOM in small test runners (which lack swap)