### PR TITLE
[misc] Remove MacOS support claim for census builder

### DIFF
--- a/tools/cellxgene_census_builder/pyproject.toml
+++ b/tools/cellxgene_census_builder/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Operating System :: POSIX :: Linux",
-    "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3.11",
 ]
 dependencies= [

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/experiment_builder.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/experiment_builder.py
@@ -301,7 +301,7 @@ def accumulate_axes_dataframes(
             return obs_df, var_df
 
     datasets_bag = dask.bag.from_sequence(datasets)
-    df_pairs_per_eb: list[tuple[pd.DataFrame, pd.DataFrame]] = dask.compute(
+    df_pairs_per_eb: list[list[tuple[pd.DataFrame, pd.DataFrame]]] = dask.compute(
         *[
             datasets_bag.map(
                 get_obs_and_var,


### PR DESCRIPTION
### Changes

- Remove MacOS support claim for census builder
- Fix type annotation of the dask computation that returns a list of `obs` and `var` dataframe as tuples