### PR TITLE
[ci] Fix torch dependency issue and pause tests on Mac/Python3.8

### DIFF
--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [single-cell-8c64g-runner, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -11,7 +11,7 @@ jobs:
   unit_tests_python_api:
     strategy:
       matrix:
-        os: [single-cell-8c64g-runner]
+        os: [single-cell-8c64g-runner, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{matrix.os}}

--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -11,8 +11,8 @@ jobs:
   unit_tests_python_api:
     strategy:
       matrix:
-        os: [single-cell-8c64g-runner, macos-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        os: [single-cell-8c64g-runner]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         os: [single-cell-8c64g-runner, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        exclude:
+          - os: macos-latest
+            python-version: "3.8"
 
     runs-on: ${{matrix.os}}
 

--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -41,7 +41,7 @@ dependencies= [
 
 [project.optional-dependencies]
 experimental = [
-    "torch~=2.2",
+    "torch~=2.2.0",
     "torchdata~=0.7",
     "scikit-learn~=1.0",
     "scikit-misc>=0.2",  # scikit-misc 0.3 dropped Python 3.8 support

--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -41,7 +41,7 @@ dependencies= [
 
 [project.optional-dependencies]
 experimental = [
-    "torch~=2.0",
+    "torch~=2.2",
     "torchdata~=0.7",
     "scikit-learn~=1.0",
     "scikit-misc>=0.2",  # scikit-misc 0.3 dropped Python 3.8 support


### PR DESCRIPTION
1. Pins torch to 2.2.x, as 2.3.x is causing dependency issues (these will eventually be fixed, so we should periodically retry unpinning the dependency)
2. Pause python 3.8 tests on the MacOS runner, at least temporarily. This is an issue with `gfortran` - maybe something like https://github.com/actions/runner-images/issues/3371 could help with solving the issue.