### PR TITLE
Vector indexing pipeline for Census embeddings

### DIFF
--- a/tools/census_embeddings_indexer/Dockerfile
+++ b/tools/census_embeddings_indexer/Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:22.04
+# TILEDB_VECTOR_SEARCH_VERSION should be the newest that doesn't need a newer version of tiledb
+# than the client tiledbsoma: https://github.com/TileDB-Inc/TileDB-Vector-Search/blob/0.2.2/pyproject.toml
+ARG TILEDB_VECTOR_SEARCH_VERSION=0.2.2
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3-pip
-RUN pip3 install tiledb-vector-search==0.4.1
-RUN pip3 install cellxgene_census
+RUN pip3 install \
+    cellxgene_census \
+    tiledb-vector-search==$TILEDB_VECTOR_SEARCH_VERSION

--- a/tools/census_embeddings_indexer/Dockerfile
+++ b/tools/census_embeddings_indexer/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:22.04
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    python3-pip
+RUN pip3 install \
+    tiledb-vector-search==0.0.23 \
+    cellxgene_census

--- a/tools/census_embeddings_indexer/Dockerfile
+++ b/tools/census_embeddings_indexer/Dockerfile
@@ -1,6 +1,5 @@
 FROM ubuntu:22.04
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3-pip
-RUN pip3 install \
-    tiledb-vector-search==0.0.23 \
-    cellxgene_census
+RUN pip3 install tiledb-vector-search==0.4.1
+RUN pip3 install cellxgene_census

--- a/tools/census_embeddings_indexer/README.md
+++ b/tools/census_embeddings_indexer/README.md
@@ -1,0 +1,22 @@
+# census_embeddings_indexer
+
+This is a Docker+WDL pipeline for building [TileDB-Vector-Search](https://github.com/TileDB-Inc/TileDB-Vector-Search) indexes for Census cell embeddings, supporting cell similarity search in embedding space. The pipeline consumes one or more of the existing TileDB arrays for hosted and contributed [Census embeddings](https://cellxgene.cziscience.com/census-models) stored on S3. The resulting indexes are themselves TileDB groups to be stored on S3.
+
+```
+export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+AWS_DEFAULT_REGION=$(aws configure get region)
+export ECR_ENDPT=${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com
+
+docker build -t ${ECR_ENDPT}/omics:census_embeddings_indexer .
+aws ecr get-login-password | docker login --username AWS --password-stdin "$ECR_ENDPT"
+docker push ${ECR_ENDPT}/omics:census_embeddings_indexer
+
+miniwdl-omics-run census_embeddings_indexer.wdl \
+    embeddings_s3_uris=s3_//cellxgene-census-public-us-west-2/cell-census/2023-12-15/soma/census_data/homo_sapiens/ms/RNA/obsm/scvi \
+    s3_region=$AWS_DEFAULT_REGION \
+    docker=${ECR_ENDPT}/omics:census_embeddings_indexer \
+    --output-uri s3://mlin-census-scratch/census_embeddings_indexer/out/ \
+    --role poweromics
+```
+
+(The `embeddings_s3_uris=s3_//...` is a workaround for an AWS-side existence check that doesn't seem to work right on public buckets.)

--- a/tools/census_embeddings_indexer/README.md
+++ b/tools/census_embeddings_indexer/README.md
@@ -26,3 +26,5 @@ miniwdl-omics-run census_embeddings_indexer.wdl \
 ```
 
 (The `embeddings_s3_uris=s3_//...` with `s3_//` instead of `s3://` is a workaround for an AWS-side existence check that doesn't seem to work right on public buckets.)
+
+The Dockerfile has an argument for the TileDB-Vector-Search version to use. We should use the newest version that doesn't need a newer version of TileDB than the intended client tiledbsoma/cellxgene_census.

--- a/tools/census_embeddings_indexer/README.md
+++ b/tools/census_embeddings_indexer/README.md
@@ -1,6 +1,8 @@
 # census_embeddings_indexer
 
-This is a Docker+WDL pipeline for building [TileDB-Vector-Search](https://github.com/TileDB-Inc/TileDB-Vector-Search) indexes for Census cell embeddings, supporting cell similarity search in embedding space. The pipeline consumes one or more of the existing TileDB arrays for hosted and contributed [Census embeddings](https://cellxgene.cziscience.com/census-models) stored on S3. The resulting indexes are themselves TileDB groups to be stored on S3.
+This is a Docker+WDL pipeline to build [TileDB-Vector-Search](https://github.com/TileDB-Inc/TileDB-Vector-Search) indexes for Census cell embeddings, supporting cell similarity search in embedding space. It's meant to run on the AWS HealthOmics workflow service using the [miniwdl-omics-run](https://github.com/miniwdl-ext/miniwdl-omics-run) launcher (assuming account setup documented there).
+
+The pipeline consumes one or more of the existing TileDB arrays for hosted and contributed [Census embeddings](https://cellxgene.cziscience.com/census-models) stored on S3. The resulting indexes are themselves TileDB groups to be stored on S3.
 
 ```
 export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)

--- a/tools/census_embeddings_indexer/README.md
+++ b/tools/census_embeddings_indexer/README.md
@@ -18,6 +18,7 @@ miniwdl-omics-run census_embeddings_indexer.wdl \
     embeddings_s3_uris=s3_//cellxgene-contrib-public/contrib/cell-census/soma/2023-12-15/CxG-czi-5 \
     embeddings_s3_uris=s3_//cellxgene-contrib-public/contrib/cell-census/soma/2023-12-15/CxG-contrib-1 \
     embeddings_s3_uris=s3_//cellxgene-contrib-public/contrib/cell-census/soma/2023-12-15/CxG-contrib-2 \
+    census_version=2023-12-15 \
     s3_region=$AWS_DEFAULT_REGION \
     docker=${ECR_ENDPT}/omics:census_embeddings_indexer \
     --output-uri s3://mlin-census-scratch/census_embeddings_indexer/out/ \

--- a/tools/census_embeddings_indexer/README.md
+++ b/tools/census_embeddings_indexer/README.md
@@ -15,9 +15,11 @@ docker push ${ECR_ENDPT}/omics:census_embeddings_indexer
 
 miniwdl-omics-run census_embeddings_indexer.wdl \
     embeddings_s3_uris=s3_//cellxgene-contrib-public/contrib/cell-census/soma/2023-12-15/CxG-czi-1 \
+    embeddings_s3_uris=s3_//cellxgene-contrib-public/contrib/cell-census/soma/2023-12-15/CxG-czi-4 \
     embeddings_s3_uris=s3_//cellxgene-contrib-public/contrib/cell-census/soma/2023-12-15/CxG-czi-5 \
     embeddings_s3_uris=s3_//cellxgene-contrib-public/contrib/cell-census/soma/2023-12-15/CxG-contrib-1 \
     embeddings_s3_uris=s3_//cellxgene-contrib-public/contrib/cell-census/soma/2023-12-15/CxG-contrib-2 \
+    embeddings_s3_uris=s3_//cellxgene-contrib-public/contrib/cell-census/soma/2023-12-15/CxG-contrib-3 \
     census_version=2023-12-15 \
     s3_region=$AWS_DEFAULT_REGION \
     docker=${ECR_ENDPT}/omics:census_embeddings_indexer \

--- a/tools/census_embeddings_indexer/README.md
+++ b/tools/census_embeddings_indexer/README.md
@@ -4,7 +4,7 @@ This is a Docker+WDL pipeline to build [TileDB-Vector-Search](https://github.com
 
 The pipeline consumes one or more of the existing TileDB arrays for hosted and contributed [Census embeddings](https://cellxgene.cziscience.com/census-models) stored on S3. The resulting indexes are themselves TileDB groups to be stored on S3.
 
-```
+```bash
 export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 AWS_DEFAULT_REGION=$(aws configure get region)
 export ECR_ENDPT=${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com

--- a/tools/census_embeddings_indexer/README.md
+++ b/tools/census_embeddings_indexer/README.md
@@ -6,8 +6,9 @@ The pipeline consumes one or more of the existing TileDB arrays for hosted and c
 
 ```bash
 export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-AWS_DEFAULT_REGION=$(aws configure get region)
-export ECR_ENDPT=${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com
+export AWS_DEFAULT_REGION=$(aws configure get region)
+export ECR_ENDPT=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+export WDL_OUTPUT_BUCKET=mlin-census-screatch
 
 docker build -t ${ECR_ENDPT}/omics:census_embeddings_indexer .
 aws ecr get-login-password | docker login --username AWS --password-stdin "$ECR_ENDPT"
@@ -23,7 +24,7 @@ miniwdl-omics-run census_embeddings_indexer.wdl \
     census_version=2023-12-15 \
     s3_region=$AWS_DEFAULT_REGION \
     docker=${ECR_ENDPT}/omics:census_embeddings_indexer \
-    --output-uri s3://mlin-census-scratch/census_embeddings_indexer/out/ \
+    --output-uri s3://${WDL_OUTPUT_BUCKET}/census_embeddings_indexer/out/ \
     --role poweromics
 ```
 

--- a/tools/census_embeddings_indexer/README.md
+++ b/tools/census_embeddings_indexer/README.md
@@ -14,11 +14,14 @@ aws ecr get-login-password | docker login --username AWS --password-stdin "$ECR_
 docker push ${ECR_ENDPT}/omics:census_embeddings_indexer
 
 miniwdl-omics-run census_embeddings_indexer.wdl \
-    embeddings_s3_uris=s3_//cellxgene-census-public-us-west-2/cell-census/2023-12-15/soma/census_data/homo_sapiens/ms/RNA/obsm/scvi \
+    embeddings_s3_uris=s3_//cellxgene-contrib-public/contrib/cell-census/soma/2023-12-15/CxG-czi-1 \
+    embeddings_s3_uris=s3_//cellxgene-contrib-public/contrib/cell-census/soma/2023-12-15/CxG-czi-5 \
+    embeddings_s3_uris=s3_//cellxgene-contrib-public/contrib/cell-census/soma/2023-12-15/CxG-contrib-1 \
+    embeddings_s3_uris=s3_//cellxgene-contrib-public/contrib/cell-census/soma/2023-12-15/CxG-contrib-2 \
     s3_region=$AWS_DEFAULT_REGION \
     docker=${ECR_ENDPT}/omics:census_embeddings_indexer \
     --output-uri s3://mlin-census-scratch/census_embeddings_indexer/out/ \
     --role poweromics
 ```
 
-(The `embeddings_s3_uris=s3_//...` is a workaround for an AWS-side existence check that doesn't seem to work right on public buckets.)
+(The `embeddings_s3_uris=s3_//...` with `s3_//` instead of `s3://` is a workaround for an AWS-side existence check that doesn't seem to work right on public buckets.)

--- a/tools/census_embeddings_indexer/census_embeddings_indexer.wdl
+++ b/tools/census_embeddings_indexer/census_embeddings_indexer.wdl
@@ -64,7 +64,7 @@ task indexer {
 
     runtime {
         cpu: cpu
-        memory: "~{2*cpu}G"
+        memory: "~{4*cpu}G"
         docker: docker
     }
 

--- a/tools/census_embeddings_indexer/census_embeddings_indexer.wdl
+++ b/tools/census_embeddings_indexer/census_embeddings_indexer.wdl
@@ -5,6 +5,7 @@ workflow census_embeddings_indexer {
         # S3 folder URIs e.g.
         # s3_//cellxgene-census-public-us-west-2/cell-census/2023-12-15/soma/census_data/homo_sapiens/ms/RNA/obsm/scvi
         Array[String] embeddings_s3_uris        
+        String census_version
         String s3_region = "us-west-2"
         String docker
     }
@@ -18,7 +19,9 @@ workflow census_embeddings_indexer {
 
     call make_one_directory {
         input:
-        directories = indexer.index, docker
+        directories = indexer.index,
+        directory_name = census_version,
+        docker
     }
 
     output {

--- a/tools/census_embeddings_indexer/census_embeddings_indexer.wdl
+++ b/tools/census_embeddings_indexer/census_embeddings_indexer.wdl
@@ -98,7 +98,7 @@ task make_one_directory {
         set -euxo pipefail
         mkdir -p '~{directory_name}'
         while read -r dir; do
-            cp -r "$dir" '~{directory_name}'
+            cp -r "$dir" '~{directory_name}/'
         done < '~{manifest}'
     >>>
 
@@ -108,5 +108,6 @@ task make_one_directory {
 
     runtime {
         docker: docker
+        memory: "4G"
     }
 }

--- a/tools/census_embeddings_indexer/census_embeddings_indexer.wdl
+++ b/tools/census_embeddings_indexer/census_embeddings_indexer.wdl
@@ -29,7 +29,7 @@ task indexer {
         Int partitions = 100
 
         String docker
-        Int cpu = 16
+        Int cpu = 32
     }
 
     command <<<
@@ -57,14 +57,14 @@ task indexer {
             training_sampling_policy=vs.ingestion.TrainingSamplingPolicy.RANDOM
         )
 
-        with vs.ivf_flat_index.IVFFlatIndex(uri="./~{embeddings_name}", memory_budget=1024*1048756) as final_index:
-            assert final_index.size == emb_shape[0]
+        final_index = vs.ivf_flat_index.IVFFlatIndex(uri="./~{embeddings_name}", memory_budget=1024*1048756)
+        assert final_index.size == emb_shape[0]
         EOF
     >>>
 
     runtime {
         cpu: cpu
-        memory: "~{4*cpu}G"
+        memory: "~{8*cpu}G"
         docker: docker
     }
 

--- a/tools/census_embeddings_indexer/census_embeddings_indexer.wdl
+++ b/tools/census_embeddings_indexer/census_embeddings_indexer.wdl
@@ -1,0 +1,74 @@
+version development
+
+workflow census_embeddings_indexer {
+    input {
+        # S3 folder URIs e.g.
+        # s3_//cellxgene-census-public-us-west-2/cell-census/2023-12-15/soma/census_data/homo_sapiens/ms/RNA/obsm/scvi
+        Array[String] embeddings_s3_uris        
+        String s3_region = "us-west-2"
+        String docker
+    }
+
+    scatter (embeddings_s3_uri in embeddings_s3_uris) {
+        call indexer {
+            input:
+            embeddings_s3_uri, s3_region, docker
+        }
+    }
+
+    output {
+        Array[Directory] indexes = indexer.index
+    }
+}
+
+task indexer {
+    input {
+        String embeddings_s3_uri
+        String s3_region
+        String embeddings_name = basename(embeddings_s3_uri)
+        Int partitions = 100
+
+        String docker
+        Int cpu = 16
+    }
+
+    command <<<
+        set -euxo pipefail
+
+        python3 << 'EOF'
+        import tiledb
+        import tiledb.vector_search as vs
+
+        config = tiledb.Config().dict()
+        config["vfs.s3.region"] = "~{s3_region}"
+
+        source_uri = "~{embeddings_s3_uri}".replace("s3_//", "s3://")
+        with tiledb.open(source_uri, config=config) as emb_array:
+            emb_shape = emb_array.shape
+
+        vs.ingest(
+            config=config,
+            source_uri=source_uri,
+            source_type="TILEDB_SPARSE_ARRAY",
+            dimensions=emb_shape[1],
+            index_type="IVF_FLAT",
+            index_uri="./~{embeddings_name}",
+            partitions=~{partitions},
+            training_sampling_policy=vs.ingestion.TrainingSamplingPolicy.RANDOM
+        )
+
+        with vs.ivf_flat_index.IVFFlatIndex(uri="./~{embeddings_name}", memory_budget=1024*1048756) as final_index:
+            assert final_index.size == emb_shape[0]
+        EOF
+    >>>
+
+    runtime {
+        cpu: cpu
+        memory: "~{2*cpu}G"
+        docker: docker
+    }
+
+    output {
+        Directory index = "~{embeddings_name}"
+    }
+}


### PR DESCRIPTION
#1112 

Adds a Docker+WDL pipeline to build the [TileDB-Vector-Search](https://github.com/TileDB-Inc/TileDB-Vector-Search) index for each Census embedding. (Excluding NMF for now due to some minor technical issues that will be easier to deal with after future improvements to TileDB-Vector-Search.)

The pipeline launches a powerful instance to build the index for each embedding, and processes the embeddings in parallel. The longest takes 9-10 hours to build (UCE, which has the highest dimensionality). The output is an S3 folder which can be copied into the destination bucket. 