### PR TITLE
[R] Fix R dependency workflow

### DIFF
--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         tiledbsoma_version: [tiledbsoma_release, tiledbsoma_latest]
-    runs-on: [ubuntu-latest, macos-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         tiledbsoma_version: [tiledbsoma_release, tiledbsoma_latest]
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/r-dependency-check.yml
+++ b/.github/workflows/r-dependency-check.yml
@@ -31,7 +31,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           brew install openssl@1.1
-          brew link openssl@1.1 --force
+          brew link --overwrite openssl@1.1
       - name: install cellxgene.census and dependencies (Linux)
         if: matrix.os != 'macos-latest'
         # This should follow our user-facing instructions to install cellxgene.census.

--- a/.github/workflows/r-dependency-check.yml
+++ b/.github/workflows/r-dependency-check.yml
@@ -27,12 +27,9 @@ jobs:
       - name: install packages (macOS)
         if: matrix.os == 'macos-latest'
         run: Rscript -e 'install.packages(c("igraph"), type="binary")'
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-      - name: install openssl via Homebrew
+      - name: Fix xcode-select on macOS
         if: matrix.os == 'macos-latest'
-        run: brew install openssl
+        run: xcode-select --install
       - name: install cellxgene.census and dependencies (Linux)
         # This should follow our user-facing instructions to install cellxgene.census.
         run: |

--- a/.github/workflows/r-dependency-check.yml
+++ b/.github/workflows/r-dependency-check.yml
@@ -39,7 +39,7 @@ jobs:
             Rscript -e 'install.packages(c("cellxgene.census", "Seurat", "BiocManager", "testthat"), repos=c("https://chanzuckerberg.r-universe.dev", "https://cloud.r-project.org"), type="source")'
             Rscript -e 'BiocManager::install("SingleCellExperiment")'
       - name: install cellxgene.census and dependencies (Mac)
-        if: matrix.os != 'macos-latest'
+        if: matrix.os == 'macos-latest'
         run : |
           export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
           export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"

--- a/.github/workflows/r-dependency-check.yml
+++ b/.github/workflows/r-dependency-check.yml
@@ -43,7 +43,8 @@ jobs:
         run : |
           export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
           export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
-          Rscript -e 'install.packages(c("cellxgene.census", "testthat"), repos=c("https://chanzuckerberg.r-universe.dev", "https://cloud.r-project.org"))'
+          Rscript -e 'install.packages(c("cellxgene.census", "Seurat", "BiocManager", "testthat"), repos=c("https://chanzuckerberg.r-universe.dev", "https://cloud.r-project.org"))'
+          Rscript -e 'BiocManager::install("SingleCellExperiment")'
       - name: run unit tests
         # [re-]fetch the cellxgene.census source package which includes the unit test code to run
         run: |

--- a/.github/workflows/r-dependency-check.yml
+++ b/.github/workflows/r-dependency-check.yml
@@ -27,24 +27,11 @@ jobs:
       - name: install packages (macOS)
         if: matrix.os == 'macos-latest'
         run: Rscript -e 'install.packages(c("igraph"), type="binary")'
-      - name: Misc openssl fixes
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew install openssl@1.1
-          brew link --overwrite openssl@1.1
-      - name: install cellxgene.census and dependencies (Linux)
-        if: matrix.os != 'macos-latest'
+      - name: install cellxgene.census and dependencies
         # This should follow our user-facing instructions to install cellxgene.census.
         run: |
-            Rscript -e 'install.packages(c("cellxgene.census", "Seurat", "BiocManager", "testthat"), repos=c("https://chanzuckerberg.r-universe.dev", "https://cloud.r-project.org"), type="source")'
+            Rscript -e 'install.packages(c("cellxgene.census", "Seurat", "BiocManager", "testthat"), repos=c("https://chanzuckerberg.r-universe.dev", "https://cloud.r-project.org"))'
             Rscript -e 'BiocManager::install("SingleCellExperiment")'
-      - name: install cellxgene.census and dependencies (Mac)
-        if: matrix.os == 'macos-latest'
-        run : |
-          export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
-          export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
-          Rscript -e 'install.packages(c("cellxgene.census", "Seurat", "BiocManager", "testthat"), repos=c("https://chanzuckerberg.r-universe.dev", "https://cloud.r-project.org"))'
-          Rscript -e 'BiocManager::install("SingleCellExperiment")'
       - name: run unit tests
         # [re-]fetch the cellxgene.census source package which includes the unit test code to run
         run: |

--- a/.github/workflows/r-dependency-check.yml
+++ b/.github/workflows/r-dependency-check.yml
@@ -27,14 +27,23 @@ jobs:
       - name: install packages (macOS)
         if: matrix.os == 'macos-latest'
         run: Rscript -e 'install.packages(c("igraph"), type="binary")'
-      - name: Fix xcode-select on macOS
+      - name: Misc openssl fixes
         if: matrix.os == 'macos-latest'
-        run: xcode-select --install
+        run: |
+          brew install openssl@1.1
+          brew link openssl@1.1 --force
       - name: install cellxgene.census and dependencies (Linux)
+        if: matrix.os != 'macos-latest'
         # This should follow our user-facing instructions to install cellxgene.census.
         run: |
             Rscript -e 'install.packages(c("cellxgene.census", "Seurat", "BiocManager", "testthat"), repos=c("https://chanzuckerberg.r-universe.dev", "https://cloud.r-project.org"), type="source")'
             Rscript -e 'BiocManager::install("SingleCellExperiment")'
+      - name: install cellxgene.census and dependencies (Mac)
+        if: matrix.os != 'macos-latest'
+        run : |
+          export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
+          export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
+          Rscript -e 'install.packages(c("cellxgene.census", "testthat"), repos=c("https://chanzuckerberg.r-universe.dev", "https://cloud.r-project.org"))'
       - name: run unit tests
         # [re-]fetch the cellxgene.census source package which includes the unit test code to run
         run: |

--- a/.github/workflows/r-dependency-check.yml
+++ b/.github/workflows/r-dependency-check.yml
@@ -27,6 +27,12 @@ jobs:
       - name: install packages (macOS)
         if: matrix.os == 'macos-latest'
         run: Rscript -e 'install.packages(c("igraph"), type="binary")'
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: install openssl via Homebrew
+        if: matrix.os == 'macos-latest'
+        run: brew install openssl
       - name: install cellxgene.census and dependencies (Linux)
         # This should follow our user-facing instructions to install cellxgene.census.
         run: |


### PR DESCRIPTION
Removes the requirement to install from source. This is not required on Mac and it only causes unnecessary headaches.