### PR TITLE
Add python 3.8/MacOS exclusion rule for dependency check workflow

### DIFF
--- a/.github/workflows/py-dependency-check.yml
+++ b/.github/workflows/py-dependency-check.yml
@@ -23,6 +23,9 @@ jobs:
       matrix:
         os: [single-cell-8c64g-runner, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        exclude:
+          - os: macos-latest
+            python-version: "3.8"
 
     runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
Required (at least for now) due to an issue with Python 3.8 on the MacOS runners.