### PR TITLE
[python] Balance distributed partition size more evenly

### DIFF
--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
@@ -570,8 +570,8 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsAndXDatum]]):  # type: ig
                 num_dist_partitions=dist.get_world_size() if dist.is_initialized() else 1,
             )
 
-            # first unchunk (flatten), so that when we subset to a partition, we splitting on rows, not chunks (which would create more imbalanced partitions)
-            # flatten obs_joinids_chunked
+            # first unchunk (flatten), so that when we subset to a partition the splitting is performed on
+            # rows and not chunks, which would create more imbalanced partitions
             obs_joinids = np.concatenate(obs_joinids_chunked)
             obs_joinids_partition = self._subset_ids_to_partition(obs_joinids, partition, partitions)
             obs_joinids_chunked = self._chunk_ids(obs_joinids_partition, self.soma_chunk_size)

--- a/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
+++ b/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
@@ -388,7 +388,7 @@ def test_multiprocessing__returns_full_result(soma_experiment: Experiment) -> No
     assert sorted(soma_joinids) == list(range(6))
 
 
-# @pytest.mark.experimental
+@pytest.mark.experimental
 # noinspection PyTestParametrized
 @pytest.mark.parametrize(
     "obs_range,var_range,X_value_gen,soma_chunk_size,rank,expected",
@@ -437,9 +437,6 @@ def test_distributed__returns_data_partition_for_rank(
 
         soma_joinids = [t[1][0].item() for t in full_result]
 
-        # Of the 6 obs rows, the PyTorch process of rank 1 should get [2, 3]
-        # (rank 0 gets [0, 1], rank 2 gets [4, 5])
-        print(soma_joinids)
         assert sorted(soma_joinids) == expected
 
 


### PR DESCRIPTION
Fixes #1119 

Generate the partitions by splitting on obs_joinids instead of on soma chunks.

Previously, when the number of soma chunks was not evenly divisible by the partition count ("world size"), partition sizes could become drastically imbalanced.

The new algo for shuffled, partitioned ids is:
1. Chunk global ids into soma chunks
2. Globally shuffle the chunks (do not shuffle the chunks internally)
3. Create a flat list of global ids again
4. Partition the flat list of globals id, and select the ids for the current partition
5. Chunk into soma chunks (again) within the partition

When performing partitioning _without_ shuffling, the soma chunks from step 1 may end up being split across two partitions. This introduces a _minor_ read performance hit, since each original soma chunk that is split across partitions will result in 2 read operations instead of 1.

When performing partitioning _with_ shuffling, _each_ soma chunk from step 1 may end up being split across two soma chunks in step 5. This is because the latter chunks will not be "aligned" with the former chunks when the partition sizes are not evenly divisible by the chunk size. This introduces a 2x read performance hit in the worst case. Consider that each partition-local chunk may be composed of 2 original chunks that are not stored contiguously on disk. This could be addressed by explicitly aligning the step 5 chunks with the step 1 chunks, but this has not been implemented in the current PR.

Now, the worst case imbalance is that any two partitions will only differ in size by 1 row. This is due to the fact the numpy.array_split() evenly distributes the imbalances across the splits that it produces. Since only imbalances of size 1 can occur, it should not be necessary to drop rows or pad rows in any partition.



New unit test cases are included in `test_distributed__returns_data_partition_for_rank`, which now exercises the imbalanced cases as well. I've also added `test_distributed__returns_data_partition_for_rank_globally_shuffled` to demonstrate that global shuffling is maintained.