### PR TITLE
[ci] Allow R acceptance tests to run from a branch

### DIFF
--- a/.github/workflows/full-unittests.yml
+++ b/.github/workflows/full-unittests.yml
@@ -36,6 +36,12 @@ on:
         required: false
         default: ""
         type: string
+      tiledbsoma_r_branch:
+        # e.g.
+        description: "Install tiledbsoma from a specific branch"
+        required: false
+        default: ""
+        type: string
 
 jobs:
   py_unit_tests:
@@ -109,6 +115,13 @@ jobs:
           working-directory: ./api/r/cellxgene.census
           extra-packages: any::rcmdcheck, any::remotes
           cache: true
+
+      - name: install tiledbsoma version override
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.tiledbsoma_r_branch != ''
+        run: |
+          Rscript -e 'remove.packages(c("tiledb", "tiledbsoma"))'
+          Rscript -e 'install.packages("remotes")'
+          Rscript -e 'remotes::install_github("https://github.com/single-cell-data/TileDB-SOMA@${{ github.event.inputs.tiledbsoma_r_branch }}", subdir = "apis/r")'
 
       - name: testthat
         run: |

--- a/.github/workflows/full-unittests.yml
+++ b/.github/workflows/full-unittests.yml
@@ -38,7 +38,7 @@ on:
         type: string
       tiledbsoma_r_branch:
         # e.g.
-        description: "Install tiledbsoma from a specific branch"
+        description: "Install r-tiledbsoma from a specific branch"
         required: false
         default: ""
         type: string


### PR DESCRIPTION
Allow to run the R acceptance tests from a branch, using `remotes::install_github`. Useful with the current TileDBSOMA release process.