### PR TITLE
[python] Fix git-lfs issue when cloning Geneformer

### DIFF
--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           python -m pip install -U pip setuptools wheel
           pip install --use-pep517 accumulation-tree # Geneformer dependency needs --use-pep517 for Cython
-          pip install -r ./api/python/cellxgene_census/scripts/requirements-dev.txt
+          GIT_CLONE_PROTECTION_ACTIVE=false pip install -r ./api/python/cellxgene_census/scripts/requirements-dev.txt
           pip install -e './api/python/cellxgene_census/[experimental]'
       - name: Test with pytest (API, main tests)
         run: |


### PR DESCRIPTION
Attemps to fix an issue caused by git-lfs which is used by Geneformer tests.