### PR TITLE
[python] Progress bar for download_source_h5ad

### DIFF
--- a/api/python/cellxgene_census/src/cellxgene_census/_open.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/_open.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Optional, get_args
 
 import s3fs
 import tiledbsoma as soma
+from fsspec.callbacks import TqdmCallback
 
 from ._release_directory import (
     CensusLocator,
@@ -334,4 +335,8 @@ def download_source_h5ad(dataset_id: str, to_path: str, *, census_version: str =
         anon=True,
         cache_regions=True,
     )
-    fs.get_file(locator["uri"], to_path)
+    fs.get_file(
+        locator["uri"],
+        to_path,
+        callback=TqdmCallback(),
+    )


### PR DESCRIPTION
For #1033

Adding a progress bar for download_source_h5ad

TODO:

- [x] Tests?
- [x] Do we want a way to turn this off?
- [x] Does this display correctly in a notebook?
  - I does a text based progress bar in a vscode notebook. There is an HTML one, but the main difference is that the html one is blue.

Currently looks like:

```python
In [3]: cellxgene_census.download_source_h5ad(small_dataset.dataset_id, "tmp.h5ad")
Downloading: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 5.10M/5.10M [00:00<00:00, 17.7MB/s]
```