### PR TITLE
[python] share census objects in tests for faster test time

### DIFF
--- a/api/python/cellxgene_census/tests/conftest.py
+++ b/api/python/cellxgene_census/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import tiledbsoma as soma
 
+import cellxgene_census
 from cellxgene_census import get_default_soma_context
 
 TEST_MARKERS_SKIPPED_BY_DEFAULT = ["expensive", "experimental"]
@@ -49,3 +50,16 @@ def pytest_configure(config: pytest.Config) -> None:
 def small_mem_context() -> soma.SOMATileDBContext:
     """used to keep memory usage smaller for GHA runners."""
     return get_default_soma_context(tiledb_config={"soma.init_buffer_bytes": 32 * 1024**2})
+
+
+# Fixtures for census objects
+
+
+@pytest.fixture(scope="session")
+def census() -> soma.Collection:
+    return cellxgene_census.open_soma(census_version="latest")
+
+
+@pytest.fixture(scope="session")
+def lts_census() -> soma.Collection:
+    return cellxgene_census.open_soma(census_version="stable")

--- a/api/python/cellxgene_census/tests/test_get_anndata.py
+++ b/api/python/cellxgene_census/tests/test_get_anndata.py
@@ -7,35 +7,34 @@ import tiledbsoma as soma
 import cellxgene_census
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def census() -> soma.Collection:
     return cellxgene_census.open_soma(census_version="latest")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def lts_census() -> soma.Collection:
     return cellxgene_census.open_soma(census_version="stable")
 
 
 @pytest.mark.live_corpus
 def test_get_anndata_value_filter(census: soma.Collection) -> None:
-    with census:
-        ad = cellxgene_census.get_anndata(
-            census,
-            organism="Mus musculus",
-            obs_value_filter="tissue_general == 'vasculature'",
-            var_value_filter="feature_name in ['Gm53058', '0610010K14Rik']",
-            column_names={
-                "obs": [
-                    "soma_joinid",
-                    "cell_type",
-                    "tissue",
-                    "tissue_general",
-                    "assay",
-                ],
-                "var": ["soma_joinid", "feature_id", "feature_name", "feature_length"],
-            },
-        )
+    ad = cellxgene_census.get_anndata(
+        census,
+        organism="Mus musculus",
+        obs_value_filter="tissue_general == 'vasculature'",
+        var_value_filter="feature_name in ['Gm53058', '0610010K14Rik']",
+        column_names={
+            "obs": [
+                "soma_joinid",
+                "cell_type",
+                "tissue",
+                "tissue_general",
+                "assay",
+            ],
+            "var": ["soma_joinid", "feature_id", "feature_name", "feature_length"],
+        },
+    )
 
     assert ad is not None
     assert ad.n_vars == 2
@@ -46,13 +45,12 @@ def test_get_anndata_value_filter(census: soma.Collection) -> None:
 
 @pytest.mark.live_corpus
 def test_get_anndata_coords(census: soma.Collection) -> None:
-    with census:
-        ad = cellxgene_census.get_anndata(
-            census,
-            organism="Mus musculus",
-            obs_coords=slice(1000),
-            var_coords=slice(2000),
-        )
+    ad = cellxgene_census.get_anndata(
+        census,
+        organism="Mus musculus",
+        obs_coords=slice(1000),
+        var_coords=slice(2000),
+    )
 
     assert ad is not None
     assert ad.n_vars == 2001
@@ -63,36 +61,32 @@ def test_get_anndata_coords(census: soma.Collection) -> None:
 def test_get_anndata_allows_missing_obs_or_var_filter(census: soma.Collection) -> None:
     # This test is slightly sensitive to the live data, in that it assumes the
     # existance of certain cell tissue labels and gene feature ids.
-    with census:
-        mouse = census["census_data"]["mus_musculus"]
+    mouse = census["census_data"]["mus_musculus"]
 
-        adata = cellxgene_census.get_anndata(census, organism="Mus musculus", obs_value_filter="tissue == 'aorta'")
-        assert adata.n_obs == len(
-            mouse.obs.read(value_filter="tissue == 'aorta'", column_names=["soma_joinid"]).concat()
-        )
-        assert adata.n_vars == len(mouse.ms["RNA"].var.read(column_names=["soma_joinid"]).concat())
+    adata = cellxgene_census.get_anndata(census, organism="Mus musculus", obs_value_filter="tissue == 'aorta'")
+    assert adata.n_obs == len(mouse.obs.read(value_filter="tissue == 'aorta'", column_names=["soma_joinid"]).concat())
+    assert adata.n_vars == len(mouse.ms["RNA"].var.read(column_names=["soma_joinid"]).concat())
 
-        adata = cellxgene_census.get_anndata(
-            census,
-            organism="Mus musculus",
-            obs_coords=slice(10000),
-            var_value_filter="feature_id == 'ENSMUSG00000069581'",
-        )
-        assert adata.n_obs == 10001
-        assert adata.n_vars == 1
+    adata = cellxgene_census.get_anndata(
+        census,
+        organism="Mus musculus",
+        obs_coords=slice(10000),
+        var_value_filter="feature_id == 'ENSMUSG00000069581'",
+    )
+    assert adata.n_obs == 10001
+    assert adata.n_vars == 1
 
 
 @pytest.mark.live_corpus
 @pytest.mark.parametrize("layer", ["raw", "normalized"])
 def test_get_anndata_x_layer(census: soma.Collection, layer: str) -> None:
-    with census:
-        ad = cellxgene_census.get_anndata(
-            census,
-            organism="Homo sapiens",
-            X_name=layer,
-            obs_coords=slice(100),
-            var_coords=slice(200),
-        )
+    ad = cellxgene_census.get_anndata(
+        census,
+        organism="Homo sapiens",
+        X_name=layer,
+        obs_coords=slice(100),
+        var_coords=slice(200),
+    )
 
     assert ad.X.shape == (101, 201)
     assert len(ad.layers) == 0
@@ -101,31 +95,30 @@ def test_get_anndata_x_layer(census: soma.Collection, layer: str) -> None:
 @pytest.mark.live_corpus
 @pytest.mark.parametrize("layers", [["raw", "normalized"], ["normalized", "raw"]])
 def test_get_anndata_two_layers(census: soma.Collection, layers: List[str]) -> None:
-    with census:
-        ad_primary_layer_in_X = cellxgene_census.get_anndata(
-            census,
-            organism="Homo sapiens",
-            X_name=layers[0],
-            obs_coords=slice(100),
-            var_coords=slice(200),
-        )
+    ad_primary_layer_in_X = cellxgene_census.get_anndata(
+        census,
+        organism="Homo sapiens",
+        X_name=layers[0],
+        obs_coords=slice(100),
+        var_coords=slice(200),
+    )
 
-        ad_secondary_layer_in_X = cellxgene_census.get_anndata(
-            census,
-            organism="Homo sapiens",
-            X_name=layers[1],
-            obs_coords=slice(100),
-            var_coords=slice(200),
-        )
+    ad_secondary_layer_in_X = cellxgene_census.get_anndata(
+        census,
+        organism="Homo sapiens",
+        X_name=layers[1],
+        obs_coords=slice(100),
+        var_coords=slice(200),
+    )
 
-        ad_multiple_layers = cellxgene_census.get_anndata(
-            census,
-            organism="Homo sapiens",
-            X_name=layers[0],
-            X_layers=[layers[1]],
-            obs_coords=slice(100),
-            var_coords=slice(200),
-        )
+    ad_multiple_layers = cellxgene_census.get_anndata(
+        census,
+        organism="Homo sapiens",
+        X_name=layers[0],
+        X_layers=[layers[1]],
+        obs_coords=slice(100),
+        var_coords=slice(200),
+    )
 
     assert layers[1] in ad_multiple_layers.layers
     assert ad_multiple_layers.X.shape == (101, 201)
@@ -138,29 +131,28 @@ def test_get_anndata_two_layers(census: soma.Collection, layers: List[str]) -> N
 
 @pytest.mark.live_corpus
 def test_get_anndata_wrong_layer_names(census: soma.Collection) -> None:
-    with census:
-        with pytest.raises(ValueError) as raise_info:
-            cellxgene_census.get_anndata(
-                census,
-                organism="Homo sapiens",
-                X_name="this_layer_name_is_bad",
-                obs_coords=slice(100),
-                var_coords=slice(200),
-            )
+    with pytest.raises(ValueError) as raise_info:
+        cellxgene_census.get_anndata(
+            census,
+            organism="Homo sapiens",
+            X_name="this_layer_name_is_bad",
+            obs_coords=slice(100),
+            var_coords=slice(200),
+        )
 
-            assert raise_info.value.args[0] == "Unknown X layer name"
+        assert raise_info.value.args[0] == "Unknown X layer name"
 
-        with pytest.raises(ValueError) as raise_info:
-            cellxgene_census.get_anndata(
-                census,
-                organism="Homo sapiens",
-                X_name="raw",
-                X_layers=["this_layer_name_is_bad"],
-                obs_coords=slice(100),
-                var_coords=slice(200),
-            )
+    with pytest.raises(ValueError) as raise_info:
+        cellxgene_census.get_anndata(
+            census,
+            organism="Homo sapiens",
+            X_name="raw",
+            X_layers=["this_layer_name_is_bad"],
+            obs_coords=slice(100),
+            var_coords=slice(200),
+        )
 
-            assert raise_info.value.args[0] == "Unknown X layer name"
+        assert raise_info.value.args[0] == "Unknown X layer name"
 
 
 @pytest.mark.live_corpus
@@ -168,15 +160,14 @@ def test_get_anndata_wrong_layer_names(census: soma.Collection) -> None:
 def test_get_anndata_obsm_one_layer(lts_census: soma.Collection, obsm_layer: str) -> None:
     # NOTE: this test will break after next LTS release (>2023-12-15), since scvi and geneformer
     # won't be distributed as part of `obsm_layers` anymore. Delete this test when it happens.
-    with lts_census:
-        ad = cellxgene_census.get_anndata(
-            lts_census,
-            organism="Homo sapiens",
-            X_name="raw",
-            obs_coords=slice(100),
-            var_coords=slice(200),
-            obsm_layers=[obsm_layer],
-        )
+    ad = cellxgene_census.get_anndata(
+        lts_census,
+        organism="Homo sapiens",
+        X_name="raw",
+        obs_coords=slice(100),
+        var_coords=slice(200),
+        obsm_layers=[obsm_layer],
+    )
 
     assert len(ad.obsm.keys()) == 1
     assert obsm_layer in ad.obsm.keys()
@@ -188,15 +179,14 @@ def test_get_anndata_obsm_one_layer(lts_census: soma.Collection, obsm_layer: str
 def test_get_anndata_obsm_two_layers(lts_census: soma.Collection, obsm_layers: List[str]) -> None:
     # NOTE: this test will break after next LTS release (>2023-12-15), since scvi and geneformer
     # won't be distributed as part of `obsm_layers` anymore. Delete this test when it happens.
-    with lts_census:
-        ad = cellxgene_census.get_anndata(
-            lts_census,
-            organism="Homo sapiens",
-            X_name="raw",
-            obs_coords=slice(100),
-            var_coords=slice(200),
-            obsm_layers=obsm_layers,
-        )
+    ad = cellxgene_census.get_anndata(
+        lts_census,
+        organism="Homo sapiens",
+        X_name="raw",
+        obs_coords=slice(100),
+        var_coords=slice(200),
+        obsm_layers=obsm_layers,
+    )
 
     assert len(ad.obsm.keys()) == 2
     for obsm_layer in obsm_layers:
@@ -209,16 +199,14 @@ def test_get_anndata_obsm_two_layers(lts_census: soma.Collection, obsm_layers: L
 def test_get_anndata_obs_embeddings(lts_census: soma.Collection, obs_embeddings: List[str]) -> None:
     # NOTE: when the next LTS gets released (>2023-12-15), embeddings may or may not be available,
     # so this test could require adjustments.
-
-    with lts_census:
-        ad = cellxgene_census.get_anndata(
-            lts_census,
-            organism="Homo sapiens",
-            X_name="raw",
-            obs_coords=slice(100),
-            var_coords=slice(200),
-            obs_embeddings=obs_embeddings,
-        )
+    ad = cellxgene_census.get_anndata(
+        lts_census,
+        organism="Homo sapiens",
+        X_name="raw",
+        obs_coords=slice(100),
+        var_coords=slice(200),
+        obs_embeddings=obs_embeddings,
+    )
 
     assert len(ad.obsm.keys()) == 3
     assert len(ad.varm.keys()) == 0
@@ -233,15 +221,14 @@ def test_get_anndata_var_embeddings(lts_census: soma.Collection, var_embeddings:
     # NOTE: when the next LTS gets released (>2023-12-15), embeddings may or may not be available,
     # so this test could require adjustments.
 
-    with lts_census:
-        ad = cellxgene_census.get_anndata(
-            lts_census,
-            organism="Homo sapiens",
-            X_name="raw",
-            obs_coords=slice(100),
-            var_coords=slice(200),
-            var_embeddings=var_embeddings,
-        )
+    ad = cellxgene_census.get_anndata(
+        lts_census,
+        organism="Homo sapiens",
+        X_name="raw",
+        obs_coords=slice(100),
+        var_coords=slice(200),
+        var_embeddings=var_embeddings,
+    )
 
     assert len(ad.obsm.keys()) == 0
     assert len(ad.varm.keys()) == 1
@@ -253,14 +240,13 @@ def test_get_anndata_var_embeddings(lts_census: soma.Collection, var_embeddings:
 @pytest.mark.live_corpus
 def test_get_anndata_obsm_layers_and_add_obs_embedding_fails(lts_census: soma.Collection) -> None:
     """Fails if both `obsm_layers` and `obs_embeddings` are specified."""
-    with lts_census:
-        with pytest.raises(ValueError):
-            cellxgene_census.get_anndata(
-                lts_census,
-                organism="Homo sapiens",
-                X_name="raw",
-                obs_coords=slice(100),
-                var_coords=slice(200),
-                obsm_layers=["scvi"],
-                obs_embeddings=["scvi"],
-            )
+    with pytest.raises(ValueError):
+        cellxgene_census.get_anndata(
+            lts_census,
+            organism="Homo sapiens",
+            X_name="raw",
+            obs_coords=slice(100),
+            var_coords=slice(200),
+            obsm_layers=["scvi"],
+            obs_embeddings=["scvi"],
+        )

--- a/api/python/cellxgene_census/tests/test_get_helpers.py
+++ b/api/python/cellxgene_census/tests/test_get_helpers.py
@@ -1,23 +1,23 @@
 import pytest
 import scipy.sparse
+import tiledbsoma as soma
 
 import cellxgene_census
 from cellxgene_census._experiment import _get_experiment
 
 
 @pytest.mark.live_corpus
-def test_get_experiment() -> None:
-    with cellxgene_census.open_soma(census_version="latest") as census:
-        mouse_uri = census["census_data"]["mus_musculus"].uri
-        human_uri = census["census_data"]["homo_sapiens"].uri
+def test_get_experiment(census: soma.Collection) -> None:
+    mouse_uri = census["census_data"]["mus_musculus"].uri
+    human_uri = census["census_data"]["homo_sapiens"].uri
 
-        assert _get_experiment(census, "mus musculus").uri == mouse_uri
-        assert _get_experiment(census, "Mus musculus").uri == mouse_uri
-        assert _get_experiment(census, "mus_musculus").uri == mouse_uri
+    assert _get_experiment(census, "mus musculus").uri == mouse_uri
+    assert _get_experiment(census, "Mus musculus").uri == mouse_uri
+    assert _get_experiment(census, "mus_musculus").uri == mouse_uri
 
-        assert _get_experiment(census, "homo sapiens").uri == human_uri
-        assert _get_experiment(census, "Homo sapiens").uri == human_uri
-        assert _get_experiment(census, "homo_sapiens").uri == human_uri
+    assert _get_experiment(census, "homo sapiens").uri == human_uri
+    assert _get_experiment(census, "Homo sapiens").uri == human_uri
+    assert _get_experiment(census, "homo_sapiens").uri == human_uri
 
     with pytest.raises(ValueError):
         _get_experiment(census, "no such critter")
@@ -25,9 +25,7 @@ def test_get_experiment() -> None:
 
 @pytest.mark.live_corpus
 @pytest.mark.parametrize("organism", ["homo_sapiens", "mus_musculus"])
-def test_get_presence_matrix(organism: str) -> None:
-    census = cellxgene_census.open_soma(census_version="latest")
-
+def test_get_presence_matrix(organism: str, census: soma.Collection) -> None:
     census_datasets = census["census_info"]["datasets"].read().concat().to_pandas()
 
     pm = cellxgene_census.get_presence_matrix(census, organism)


### PR DESCRIPTION
I propose we re-use SOMA objects in testing to cut down on total test time.

From a single measurement, I see a little more than a 10% (~40 seconds) decrease in test time with this change. I've run the `get_anndata` tests on this commit and the one before it. I haven't run this many times, so I don't know what the variance is. You can see that with this commit there is far lower time taken on setup for each task (since the resource is simply removed)

### Timings on this commit

<details>

```
================================================================================ slowest durations ================================================================================
53.89s call     tests/test_get_anndata.py::test_get_anndata_allows_missing_obs_or_var_filter
34.26s call     tests/test_get_anndata.py::test_get_anndata_value_filter
33.00s call     tests/test_get_anndata.py::test_get_anndata_obs_embeddings[obs_embeddings0]
31.75s call     tests/test_get_anndata.py::test_get_anndata_two_layers[layers0]
30.18s call     tests/test_get_anndata.py::test_get_anndata_two_layers[layers1]
16.68s call     tests/test_get_anndata.py::test_get_anndata_var_embeddings[var_embeddings0]
13.84s call     tests/test_get_anndata.py::test_get_anndata_x_layer[raw]
13.23s call     tests/test_get_anndata.py::test_get_anndata_obsm_one_layer[geneformer]
12.33s call     tests/test_get_anndata.py::test_get_anndata_obsm_one_layer[scvi]
7.79s call     tests/test_get_anndata.py::test_get_anndata_x_layer[normalized]
7.64s call     tests/test_get_anndata.py::test_get_anndata_obsm_two_layers[obsm_layers0]
6.23s call     tests/test_get_anndata.py::test_get_anndata_coords
6.18s setup    tests/test_get_anndata.py::test_get_anndata_value_filter
1.29s setup    tests/test_get_anndata.py::test_get_anndata_obsm_one_layer[scvi]
0.00s teardown tests/test_get_anndata.py::test_get_anndata_obsm_layers_and_add_obs_embedding_fails
0.00s call     tests/test_get_anndata.py::test_get_anndata_obsm_layers_and_add_obs_embedding_fails
0.00s setup    tests/test_get_anndata.py::test_get_anndata_obsm_layers_and_add_obs_embedding_fails
0.00s teardown tests/test_get_anndata.py::test_get_anndata_var_embeddings[var_embeddings0]
0.00s call     tests/test_get_anndata.py::test_get_anndata_wrong_layer_names
0.00s setup    tests/test_get_anndata.py::test_get_anndata_x_layer[normalized]
0.00s setup    tests/test_get_anndata.py::test_get_anndata_x_layer[raw]
0.00s setup    tests/test_get_anndata.py::test_get_anndata_two_layers[layers1]
0.00s setup    tests/test_get_anndata.py::test_get_anndata_two_layers[layers0]
0.00s setup    tests/test_get_anndata.py::test_get_anndata_obsm_two_layers[obsm_layers0]
0.00s teardown tests/test_get_anndata.py::test_get_anndata_obs_embeddings[obs_embeddings0]
0.00s setup    tests/test_get_anndata.py::test_get_anndata_obs_embeddings[obs_embeddings0]
0.00s setup    tests/test_get_anndata.py::test_get_anndata_var_embeddings[var_embeddings0]
0.00s setup    tests/test_get_anndata.py::test_get_anndata_obsm_one_layer[geneformer]
0.00s teardown tests/test_get_anndata.py::test_get_anndata_obsm_one_layer[geneformer]
0.00s teardown tests/test_get_anndata.py::test_get_anndata_two_layers[layers0]
0.00s teardown tests/test_get_anndata.py::test_get_anndata_x_layer[normalized]
0.00s teardown tests/test_get_anndata.py::test_get_anndata_x_layer[raw]
0.00s teardown tests/test_get_anndata.py::test_get_anndata_obsm_two_layers[obsm_layers0]
0.00s teardown tests/test_get_anndata.py::test_get_anndata_two_layers[layers1]
0.00s setup    tests/test_get_anndata.py::test_get_anndata_coords
0.00s teardown tests/test_get_anndata.py::test_get_anndata_obsm_one_layer[scvi]
0.00s setup    tests/test_get_anndata.py::test_get_anndata_wrong_layer_names
0.00s teardown tests/test_get_anndata.py::test_get_anndata_value_filter
0.00s teardown tests/test_get_anndata.py::test_get_anndata_allows_missing_obs_or_var_filter
0.00s setup    tests/test_get_anndata.py::test_get_anndata_allows_missing_obs_or_var_filter
0.00s teardown tests/test_get_anndata.py::test_get_anndata_coords
0.00s teardown tests/test_get_anndata.py::test_get_anndata_wrong_layer_names
=================================================================== 14 passed, 34 warnings in 268.35s (0:04:28) ===================================================================
```

</details>

### Timings on main

<details>

```
================================================================================ slowest durations ================================================================================
44.75s call     tests/test_get_anndata.py::test_get_anndata_allows_missing_obs_or_var_filter
35.88s call     tests/test_get_anndata.py::test_get_anndata_obs_embeddings[obs_embeddings0]
34.50s call     tests/test_get_anndata.py::test_get_anndata_two_layers[layers1]
33.52s call     tests/test_get_anndata.py::test_get_anndata_two_layers[layers0]
28.05s call     tests/test_get_anndata.py::test_get_anndata_value_filter
19.20s call     tests/test_get_anndata.py::test_get_anndata_var_embeddings[var_embeddings0]
15.72s call     tests/test_get_anndata.py::test_get_anndata_obsm_two_layers[obsm_layers0]
13.25s call     tests/test_get_anndata.py::test_get_anndata_obsm_one_layer[scvi]
12.79s call     tests/test_get_anndata.py::test_get_anndata_obsm_one_layer[geneformer]
11.51s call     tests/test_get_anndata.py::test_get_anndata_x_layer[raw]
11.35s call     tests/test_get_anndata.py::test_get_anndata_x_layer[normalized]
9.00s call     tests/test_get_anndata.py::test_get_anndata_coords
6.48s setup    tests/test_get_anndata.py::test_get_anndata_value_filter
5.26s setup    tests/test_get_anndata.py::test_get_anndata_coords
5.18s setup    tests/test_get_anndata.py::test_get_anndata_two_layers[layers0]
5.18s setup    tests/test_get_anndata.py::test_get_anndata_obsm_one_layer[geneformer]
3.15s setup    tests/test_get_anndata.py::test_get_anndata_x_layer[raw]
3.06s setup    tests/test_get_anndata.py::test_get_anndata_two_layers[layers1]
2.71s call     tests/test_get_anndata.py::test_get_anndata_wrong_layer_names
1.38s setup    tests/test_get_anndata.py::test_get_anndata_x_layer[normalized]
1.31s setup    tests/test_get_anndata.py::test_get_anndata_allows_missing_obs_or_var_filter
1.29s setup    tests/test_get_anndata.py::test_get_anndata_obsm_two_layers[obsm_layers0]
1.19s setup    tests/test_get_anndata.py::test_get_anndata_obsm_layers_and_add_obs_embedding_fails
1.15s setup    tests/test_get_anndata.py::test_get_anndata_obsm_one_layer[scvi]
1.14s setup    tests/test_get_anndata.py::test_get_anndata_obs_embeddings[obs_embeddings0]
1.11s setup    tests/test_get_anndata.py::test_get_anndata_wrong_layer_names
1.08s setup    tests/test_get_anndata.py::test_get_anndata_var_embeddings[var_embeddings0]
0.65s call     tests/test_get_anndata.py::test_get_anndata_obsm_layers_and_add_obs_embedding_fails
0.00s teardown tests/test_get_anndata.py::test_get_anndata_var_embeddings[var_embeddings0]
0.00s teardown tests/test_get_anndata.py::test_get_anndata_wrong_layer_names
0.00s teardown tests/test_get_anndata.py::test_get_anndata_obsm_layers_and_add_obs_embedding_fails
0.00s teardown tests/test_get_anndata.py::test_get_anndata_obs_embeddings[obs_embeddings0]
0.00s teardown tests/test_get_anndata.py::test_get_anndata_obsm_two_layers[obsm_layers0]
0.00s teardown tests/test_get_anndata.py::test_get_anndata_obsm_one_layer[geneformer]
0.00s teardown tests/test_get_anndata.py::test_get_anndata_value_filter
0.00s teardown tests/test_get_anndata.py::test_get_anndata_x_layer[raw]
0.00s teardown tests/test_get_anndata.py::test_get_anndata_x_layer[normalized]
0.00s teardown tests/test_get_anndata.py::test_get_anndata_two_layers[layers0]
0.00s teardown tests/test_get_anndata.py::test_get_anndata_two_layers[layers1]
0.00s teardown tests/test_get_anndata.py::test_get_anndata_coords
0.00s teardown tests/test_get_anndata.py::test_get_anndata_allows_missing_obs_or_var_filter
0.00s teardown tests/test_get_anndata.py::test_get_anndata_obsm_one_layer[scvi]
=================================================================== 14 passed, 34 warnings in 310.89s (0:05:10) ===================================================================
```

</details>