### PR TITLE
[python] Don't kill all tests on failure

### DIFF
--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit_tests_python_api:
     strategy:

--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   unit_tests_python_api:
     strategy:
+      fail-fast: false
       matrix:
         os: [single-cell-8c64g-runner, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]

--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches: [main]
 
+# If a new commit is pushed, cancel the jobs from previous commits.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -14,7 +15,7 @@ concurrency:
 jobs:
   unit_tests_python_api:
     strategy:
-      fail-fast: false
+      fail-fast: false  # Don't stop the workflow if one of the jobs fails
       matrix:
         os: [single-cell-8c64g-runner, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]

--- a/api/python/cellxgene_census/tests/test_ci.py
+++ b/api/python/cellxgene_census/tests/test_ci.py
@@ -1,0 +1,6 @@
+import sys
+
+
+def test_ci() -> None:
+    if sys.version_info[1] == 10:
+        raise Exception("Python 3.10!")

--- a/api/python/cellxgene_census/tests/test_ci.py
+++ b/api/python/cellxgene_census/tests/test_ci.py
@@ -1,6 +1,0 @@
-import sys
-
-
-def test_ci() -> None:
-    if sys.version_info[1] == 10:
-        raise Exception("Python 3.10!")


### PR DESCRIPTION
It's working! You can see that on commit fafb3ff the actions all quit after one failure, but after b2058a0 they continue to run. 

~~I'm starting this with a test that should fail on some jobs, to confirm that it kills the others. Then I will modify the workflow file to make it so that doesn't happen.~~

- [x] Get rid of test that is expected to fail
- [x] Push commit with comments explaining the changes