### PR TITLE
[python] Make docs searchable

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,6 @@ source_suffix = ['.rst', '.md']
 # Inject custom css files in `/_static/css/*`
 html_static_path = ['_static']
 
-import sphinx_rtd_theme
 html_theme = "sphinx_rtd_theme"
 
 html_js_files = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,6 @@ html_static_path = ['_static']
 
 import sphinx_rtd_theme
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 html_js_files = [
     ('https://plausible.io/js/script.js', {"data-domain": "chanzuckerberg.github.io/cellxgene-census", "defer": "defer"}),


### PR DESCRIPTION
This PR addresses https://github.com/chanzuckerberg/cellxgene-census/issues/620

I've re-enabled Sphinx's built-in client side search by:

* Removing the blank template for the search bar
* Removing the line:

```python
html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
```