### PR TITLE
Identify tiledbsoma version that causes builder unit tests to fail

### DIFF
--- a/tools/cellxgene_census_builder/pyproject.toml
+++ b/tools/cellxgene_census_builder/pyproject.toml
@@ -34,7 +34,8 @@ dependencies= [
     # recent cellxgene-census _readers_ are able to read the results of a Census build (writer).
     # The compatibility matrix is defined here:
     #    https://github.com/TileDB-Inc/TileDB/blob/dev/format_spec/FORMAT_SPEC.md
-    "tiledbsoma @ git+https://github.com/single-cell-data/TileDB-SOMA.git@5419994#egg=tiledbsoma&subdirectory=apis/python/",
+    #"tiledbsoma @ git+https://github.com/single-cell-data/TileDB-SOMA.git@5419994#egg=tiledbsoma&subdirectory=apis/python/",
+    "tiledbsoma==1.11.3",
     # TODO: Temporarily commenting out cellxgene-census package. Uncomment!!! 
     # "cellxgene-census==1.12.0",
     "cellxgene-ontology-guide==0.6.1",

--- a/tools/cellxgene_census_builder/pyproject.toml
+++ b/tools/cellxgene_census_builder/pyproject.toml
@@ -34,7 +34,7 @@ dependencies= [
     # recent cellxgene-census _readers_ are able to read the results of a Census build (writer).
     # The compatibility matrix is defined here:
     #    https://github.com/TileDB-Inc/TileDB/blob/dev/format_spec/FORMAT_SPEC.md
-    "tiledbsoma @ git+https://github.com/single-cell-data/TileDB-SOMA.git@b1f7fd5#egg=tiledbsoma&subdirectory=apis/python/"
+    "tiledbsoma @ git+https://github.com/single-cell-data/TileDB-SOMA.git@b1f7fd5#egg=tiledbsoma&subdirectory=apis/python/",
     # TODO: Temporarily commenting out cellxgene-census package. Uncomment!!! 
     # "cellxgene-census==1.12.0",
     "cellxgene-ontology-guide==0.6.1",

--- a/tools/cellxgene_census_builder/pyproject.toml
+++ b/tools/cellxgene_census_builder/pyproject.toml
@@ -34,7 +34,7 @@ dependencies= [
     # recent cellxgene-census _readers_ are able to read the results of a Census build (writer).
     # The compatibility matrix is defined here:
     #    https://github.com/TileDB-Inc/TileDB/blob/dev/format_spec/FORMAT_SPEC.md
-    "tiledbsoma @ git+https://github.com/single-cell-data/TileDB-SOMA.git@a955277#egg=tiledbsoma&subdirectory=apis/python/",
+    "tiledbsoma @ git+https://github.com/single-cell-data/TileDB-SOMA.git@5419994#egg=tiledbsoma&subdirectory=apis/python/",
     # TODO: Temporarily commenting out cellxgene-census package. Uncomment!!! 
     # "cellxgene-census==1.12.0",
     "cellxgene-ontology-guide==0.6.1",

--- a/tools/cellxgene_census_builder/pyproject.toml
+++ b/tools/cellxgene_census_builder/pyproject.toml
@@ -34,7 +34,7 @@ dependencies= [
     # recent cellxgene-census _readers_ are able to read the results of a Census build (writer).
     # The compatibility matrix is defined here:
     #    https://github.com/TileDB-Inc/TileDB/blob/dev/format_spec/FORMAT_SPEC.md
-    "tiledbsoma==1.9.3",
+    "tiledbsoma==1.10.2",
     # TODO: Temporarily commenting out cellxgene-census package. Uncomment!!! 
     # "cellxgene-census==1.12.0",
     "cellxgene-ontology-guide==0.6.1",

--- a/tools/cellxgene_census_builder/pyproject.toml
+++ b/tools/cellxgene_census_builder/pyproject.toml
@@ -34,7 +34,7 @@ dependencies= [
     # recent cellxgene-census _readers_ are able to read the results of a Census build (writer).
     # The compatibility matrix is defined here:
     #    https://github.com/TileDB-Inc/TileDB/blob/dev/format_spec/FORMAT_SPEC.md
-    "tiledbsoma==1.10.2",
+    "tiledbsoma==1.11.3",
     # TODO: Temporarily commenting out cellxgene-census package. Uncomment!!! 
     # "cellxgene-census==1.12.0",
     "cellxgene-ontology-guide==0.6.1",

--- a/tools/cellxgene_census_builder/pyproject.toml
+++ b/tools/cellxgene_census_builder/pyproject.toml
@@ -34,7 +34,7 @@ dependencies= [
     # recent cellxgene-census _readers_ are able to read the results of a Census build (writer).
     # The compatibility matrix is defined here:
     #    https://github.com/TileDB-Inc/TileDB/blob/dev/format_spec/FORMAT_SPEC.md
-    "tiledbsoma==1.11.3",
+    "tiledbsoma @ git+https://github.com/single-cell-data/TileDB-SOMA.git@b1f7fd5#egg=tiledbsoma&subdirectory=apis/python/"
     # TODO: Temporarily commenting out cellxgene-census package. Uncomment!!! 
     # "cellxgene-census==1.12.0",
     "cellxgene-ontology-guide==0.6.1",

--- a/tools/cellxgene_census_builder/pyproject.toml
+++ b/tools/cellxgene_census_builder/pyproject.toml
@@ -34,7 +34,7 @@ dependencies= [
     # recent cellxgene-census _readers_ are able to read the results of a Census build (writer).
     # The compatibility matrix is defined here:
     #    https://github.com/TileDB-Inc/TileDB/blob/dev/format_spec/FORMAT_SPEC.md
-    "tiledbsoma @ git+https://github.com/single-cell-data/TileDB-SOMA.git@b1f7fd5#egg=tiledbsoma&subdirectory=apis/python/",
+    "tiledbsoma @ git+https://github.com/single-cell-data/TileDB-SOMA.git@a955277#egg=tiledbsoma&subdirectory=apis/python/",
     # TODO: Temporarily commenting out cellxgene-census package. Uncomment!!! 
     # "cellxgene-census==1.12.0",
     "cellxgene-ontology-guide==0.6.1",

--- a/tools/cellxgene_census_builder/pyproject.toml
+++ b/tools/cellxgene_census_builder/pyproject.toml
@@ -34,8 +34,8 @@ dependencies= [
     # recent cellxgene-census _readers_ are able to read the results of a Census build (writer).
     # The compatibility matrix is defined here:
     #    https://github.com/TileDB-Inc/TileDB/blob/dev/format_spec/FORMAT_SPEC.md
-    #"tiledbsoma @ git+https://github.com/single-cell-data/TileDB-SOMA.git@5419994#egg=tiledbsoma&subdirectory=apis/python/",
-    "tiledbsoma==1.11.3",
+    "tiledbsoma @ git+https://github.com/single-cell-data/TileDB-SOMA.git@3869abc#egg=tiledbsoma&subdirectory=apis/python/",
+    #"tiledbsoma==1.11.3",
     # TODO: Temporarily commenting out cellxgene-census package. Uncomment!!! 
     # "cellxgene-census==1.12.0",
     "cellxgene-ontology-guide==0.6.1",

--- a/tools/cellxgene_census_builder/pyproject.toml
+++ b/tools/cellxgene_census_builder/pyproject.toml
@@ -35,7 +35,8 @@ dependencies= [
     # The compatibility matrix is defined here:
     #    https://github.com/TileDB-Inc/TileDB/blob/dev/format_spec/FORMAT_SPEC.md
     "tiledbsoma==1.9.3",
-    "cellxgene-census==1.12.0",
+    # TODO: Temporarily commenting out cellxgene-census package. Uncomment!!! 
+    # "cellxgene-census==1.12.0",
     "cellxgene-ontology-guide==0.6.1",
     "scipy==1.12.0",
     "fsspec[http]==2024.3.1",


### PR DESCRIPTION
This PR shows the `tiledbsoma` version that causes census builder unit tests to fail