### PR TITLE
[python] Use pyproject.toml for doc env

### DIFF
--- a/.github/workflows/docsite-build-deploy.yml
+++ b/.github/workflows/docsite-build-deploy.yml
@@ -24,8 +24,7 @@ jobs:
         run: |
           python -m pip install -U pip setuptools wheel
           pip install -r ./api/python/cellxgene_census/scripts/requirements-dev.txt
-          pip install -r ./docs/requirements.txt
-          pip install -e './api/python/cellxgene_census/[experimental]'
+          pip install -e './api/python/cellxgene_census/[experimental,doc]'
           mkdir -p docsite
           touch docsite/.nojekyll
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,4 +16,6 @@ python:
   install:
     - method: pip
       path: api/python/cellxgene_census
-    - requirements: docs/requirements.txt
+      extra_requirements:
+        - doc
+        - experimental

--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -52,6 +52,13 @@ experimental = [
     #"git+https://huggingface.co/ctheodoris/Geneformer",
     # instead, experimental/ml/geneformer_tokenizer.py catches ImportError to ask user to install that.
 ]
+doc = [
+    "nbsphinx",
+    "myst-parser",
+    "sphinx-rtd-theme",
+    "gitpython",
+    "sphinx<7.0.0",
+]
 
 [project.urls]
 homepage = "https://github.com/chanzuckerberg/cellxgene-census"

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -9,7 +9,7 @@ A docsite rebuild can be [triggered manually through `workflow_dispatch`](https:
 In order to test docsite changes locally, first install the necessary requirements:
 
 ```shell
-pip install -r docs/requirements.txt
+pip install -e "api/python/cellxgene_census[experimental,doc]"
 brew install pandoc # Mac OS
 ```
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,0 @@
-nbsphinx
-myst-parser
-sphinx-rtd-theme
-gitpython
-sphinx<7.0.0


### PR DESCRIPTION
This PR moves the doc requirements over to the pyproject.toml for an easier install workflow.