### PR TITLE
[python] Restore soma indexer in hvg

### DIFF
--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/pp/_highly_variable_genes.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/pp/_highly_variable_genes.py
@@ -89,7 +89,7 @@ def _highly_variable_genes_seurat_v3(
         n_batches = len(batch_index.cat.categories)
         n_samples = batch_index.value_counts().loc[batch_index.cat.categories.to_numpy()].to_numpy()
         if n_batches > 1:
-            batch_indexer = batch_index.index.get_indexer
+            batch_indexer = soma.IntIndexer(batch_index.index.to_numpy(), context=query.experiment.context).get_indexer
             batch_codes = batch_index.cat.codes.to_numpy().astype(np.int64)
     else:
         n_batches = 1


### PR DESCRIPTION
Previously removed due a memory bug, now fixed by https://github.com/single-cell-data/TileDB-SOMA/issues/2662