### PR TITLE
[python] Relax pin: `tiledbsoma~=1.11.4`

### DIFF
--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -31,7 +31,7 @@ dependencies= [
     # NOTE: the tiledbsoma version must be >= to the version used in the Census builder, to
     # ensure that the assets are readable (tiledbsoma supports backward compatible reading).
     # Make sure this version does not fall behind the builder's tiledbsoma version.
-    "tiledbsoma==1.11.4",
+    "tiledbsoma~=1.11.4",
     "anndata",
     "numpy>=1.21,<2.0",
     "requests",


### PR DESCRIPTION
While developing, local tiledbsoma installs get version numbers like `1.11.4.post0.dev3991933300`. The `tiledbsoma==1.11.4` pin in this repo errors when attempting to install alongside such a tiledbsoma, e.g. [in arrayloader-benchmarks](https://github.com/ryan-williams/arrayloader-benchmarks?tab=readme-ov-file#install):

```bash
pip install -e cellxgene-census/api/python/cellxgene_census -e tiledb-soma/apis/python
# ERROR: Cannot install cellxgene-census==1.14.2.dev3+g5de4536.d20240606 and tiledbsoma 1.11.4.post0.dev3991933300 (from $PWD/tiledb-soma/apis/python) because these package versions have conflicting dependencies.
# 
# The conflict is caused by:
#     The user requested tiledbsoma 1.11.4.post0.dev3991933300 (from $PWD/tiledb-soma/apis/python)
#     cellxgene-census 1.14.2.dev3+g5de4536.d20240606 depends on tiledbsoma==1.11.4
# 
# To fix this you could try to:
# 1. loosen the range of package versions you've specified
# 2. remove package versions to allow pip attempt to solve the dependency conflict
```

`tiledbsoma~=1.11.4` (equivalent to `tiledbsoma>=1.11.4,<1.12.0`) lets such local installs work, and doesn't have any downsides, afaict.

(factored out of #1169)