### PR TITLE
[pytorch] Set shuffle as default in pytorch, use new algorithm

### DIFF
--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
@@ -450,7 +450,8 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsAndXDatum]]):  # type: ig
                 The randomness of the shuffling is therefore determined by the
                 (``soma_chunk_size``, ``shuffle_chunk_count``) selection. The default values have been determined
                 to yield a good trade-off between randomness and performance. Further tuning may be required for
-                different type of models.
+                different type of models. Note that memory usage is correlated to the product
+                ``soma_chunk_size * shuffle_chunk_count``.
             seed:
                 The random seed used for shuffling. Defaults to ``None`` (no seed). This *must* be specified when using
                 :class:`torch.nn.parallel.DistributedDataParallel` to ensure data partitions are disjoint across worker

--- a/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/experimental/ml/pytorch.py
@@ -445,8 +445,8 @@ class ExperimentDataPipe(pipes.IterDataPipe[Dataset[ObsAndXDatum]]):  # type: ig
             shuffle:
                 Whether to shuffle the ``obs`` and ``X`` data being returned. Defaults to ``True``.
                 For performance reasons, shuffling is not performed globally across all rows, but rather in chunks.
-                More specifically, we select ``shuffle_chunk_count`` non contiguous chunks across all the dataset,
-                concatenate them and shuffle the resulting array.
+                More specifically, we select ``shuffle_chunk_count`` non-contiguous chunks across all the observations
+                in the query, concatenate the chunks and shuffle the associated observations.
                 The randomness of the shuffling is therefore determined by the
                 (``soma_chunk_size``, ``shuffle_chunk_count``) selection. The default values have been determined
                 to yield a good trade-off between randomness and performance. Further tuning may be required for

--- a/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
+++ b/api/python/cellxgene_census/tests/experimental/ml/test_pytorch.py
@@ -142,6 +142,7 @@ def test_non_batched(soma_experiment: Experiment, use_eager_fetch: bool) -> None
         measurement_name="RNA",
         X_name="raw",
         obs_column_names=["label"],
+        shuffle=False,
         use_eager_fetch=use_eager_fetch,
     )
     row_iter = iter(exp_data_pipe)
@@ -164,6 +165,7 @@ def test_batching__all_batches_full_size(soma_experiment: Experiment, use_eager_
         X_name="raw",
         obs_column_names=["label"],
         batch_size=3,
+        shuffle=False,
         use_eager_fetch=use_eager_fetch,
     )
     batch_iter = iter(exp_data_pipe)
@@ -214,6 +216,7 @@ def test_batching__partial_final_batch_size(soma_experiment: Experiment, use_eag
         X_name="raw",
         obs_column_names=["label"],
         batch_size=3,
+        shuffle=False,
         use_eager_fetch=use_eager_fetch,
     )
     batch_iter = iter(exp_data_pipe)
@@ -239,6 +242,7 @@ def test_batching__exactly_one_batch(soma_experiment: Experiment, use_eager_fetc
         X_name="raw",
         obs_column_names=["label"],
         batch_size=3,
+        shuffle=False,
         use_eager_fetch=use_eager_fetch,
     )
     batch_iter = iter(exp_data_pipe)
@@ -286,6 +290,7 @@ def test_sparse_output__non_batched(soma_experiment: Experiment, use_eager_fetch
         X_name="raw",
         obs_column_names=["label"],
         return_sparse_X=True,
+        shuffle=False,
         use_eager_fetch=use_eager_fetch,
     )
     batch_iter = iter(exp_data_pipe)
@@ -309,6 +314,7 @@ def test_sparse_output__batched(soma_experiment: Experiment, use_eager_fetch: bo
         obs_column_names=["label"],
         batch_size=3,
         return_sparse_X=True,
+        shuffle=False,
         use_eager_fetch=use_eager_fetch,
     )
     batch_iter = iter(exp_data_pipe)
@@ -350,6 +356,7 @@ def test_encoders(soma_experiment: Experiment) -> None:
         measurement_name="RNA",
         X_name="raw",
         obs_column_names=["label"],
+        shuffle=False,
         batch_size=3,
     )
     batch_iter = iter(exp_data_pipe)
@@ -413,6 +420,7 @@ def test_distributed__returns_data_partition_for_rank(
             X_name="raw",
             obs_column_names=["label"],
             soma_chunk_size=2,
+            shuffle=False,
         )
         full_result = list(iter(dp))
 
@@ -451,6 +459,7 @@ def test_distributed_and_multiprocessing__returns_data_partition_for_rank(
             X_name="raw",
             obs_column_names=["label"],
             soma_chunk_size=2,
+            shuffle=False,
         )
 
         full_result = list(iter(dp))
@@ -475,6 +484,7 @@ def test_experiment_dataloader__non_batched(soma_experiment: Experiment, use_eag
         measurement_name="RNA",
         X_name="raw",
         obs_column_names=["label"],
+        shuffle=False,
         use_eager_fetch=use_eager_fetch,
     )
     dl = experiment_dataloader(dp)
@@ -498,6 +508,7 @@ def test_experiment_dataloader__batched(soma_experiment: Experiment, use_eager_f
         X_name="raw",
         obs_column_names=["label"],
         batch_size=3,
+        shuffle=False,
         use_eager_fetch=use_eager_fetch,
     )
     dl = experiment_dataloader(dp)


### PR DESCRIPTION
1. Set shuffle=True as the default for ExperimentDataPipe
2. Use the new scatter-gather algorithm by default
3. Set the soma_chunk_size, shuffle_chunk_count to a sensible default of (64, 2000)
4. Modify docs to explain the above changes
5. Set shuffle=False in the tests (to avoid nondeterminism) 