### PR TITLE
[python] Remove pytorch pin

### DIFF
--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -41,7 +41,7 @@ dependencies= [
 
 [project.optional-dependencies]
 experimental = [
-    "torch~=2.2.0",
+    "torch",
     "torchdata~=0.7",
     "scikit-learn~=1.0",
     "scikit-misc>=0.2",  # scikit-misc 0.3 dropped Python 3.8 support


### PR DESCRIPTION
Pin no longer required with the 2.3.1 release:
https://github.com/pytorch/pytorch/pull/122616