### PR TITLE
[python] Fix typo in embedding notebook

### DIFF
--- a/api/python/notebooks/api_demo/census_access_maintained_embeddings.ipynb
+++ b/api/python/notebooks/api_demo/census_access_maintained_embeddings.ipynb
@@ -350,7 +350,7 @@
     "adata = query.to_anndata(X_name=\"raw\", column_names={\"obs\": [\"cell_type\"]})\n",
     "\n",
     "for embedding_name in [\"scvi\", \"geneformer\"]:\n",
-    "    metadata = get_embedding_metadata_by_name(\"scvi\", \"homo_sapiens\", census_version=census_version)\n",
+    "    metadata = get_embedding_metadata_by_name(embedding_name, \"homo_sapiens\", census_version=census_version)\n",
     "    embedding_uri = (\n",
     "        f\"s3://cellxgene-contrib-public/contrib/cell-census/soma/{metadata['census_version']}/{metadata['id']}\"\n",
     "    )\n",


### PR DESCRIPTION
Fixes #1206

I've re-run the notebook locally, so don't think I've introduced a new error