### PR TITLE
[python] Require scikit-misc < 0.4

### DIFF
--- a/api/python/cellxgene_census/pyproject.toml
+++ b/api/python/cellxgene_census/pyproject.toml
@@ -44,7 +44,7 @@ experimental = [
     "torch",
     "torchdata~=0.7",
     "scikit-learn~=1.0",
-    "scikit-misc>=0.2",  # scikit-misc 0.3 dropped Python 3.8 support
+    "scikit-misc>=0.2,<0.4",  # scikit-misc 0.3 dropped Python 3.8 support, and 0.4 doesn't have MacOS/ARM wheels
     "psutil~=5.0",
     "datasets~=2.0",
     "tdigest~=0.5",


### PR DESCRIPTION
Scikit-misc 0.4 doesn't have compatible wheels for MacOS/ARM: see https://github.com/has2k1/scikit-misc/issues/37