### PR TITLE
[python] Stop including `"do_not_delete"` key in result of `get_census_version_directory`

### DIFF
--- a/api/python/cellxgene_census/src/cellxgene_census/_release_directory.py
+++ b/api/python/cellxgene_census/src/cellxgene_census/_release_directory.py
@@ -9,7 +9,7 @@ Methods to retrieve information about versions of the publicly hosted Census obj
 
 import typing
 from collections import OrderedDict
-from typing import Dict, Literal, Optional, Union, cast
+from typing import Any, Dict, Literal, Optional, Union, cast
 
 import requests
 from typing_extensions import NotRequired, TypedDict
@@ -353,7 +353,7 @@ def get_census_version_directory(
     response = requests.get(CELL_CENSUS_RELEASE_DIRECTORY_URL)
     response.raise_for_status()
 
-    directory: CensusDirectory = cast(CensusDirectory, response.json())
+    directory: dict[str, str | dict[str, Any]] = response.json()
     directory_out: CensusDirectory = {}
     aliases: typing.Set[CensusVersionName] = set()
 
@@ -378,6 +378,11 @@ def get_census_version_directory(
         # exclude aliases
         if not isinstance(directory_value, dict):
             continue
+
+        # Filter fields
+        directory_value = {
+            k: directory_value[k] for k in CensusVersionDescription.__annotations__ if k in directory_value
+        }
 
         # filter by release flags
         census_version_description = cast(CensusVersionDescription, directory_value)

--- a/api/python/cellxgene_census/tests/test_directory.py
+++ b/api/python/cellxgene_census/tests/test_directory.py
@@ -34,7 +34,6 @@ DIRECTORY_JSON = {
         "release_date": "2022-09-30",
         "release_build": "2022-09-01",
         "flags": {"lts": True, "retracted": True},
-        "do_not_delete": True,
         "retraction": {
             "date": "2022-11-15",
             "reason": "mistakes happen",
@@ -53,7 +52,6 @@ DIRECTORY_JSON = {
     "2022-11-01": {
         "release_date": "2022-11-30",
         "release_build": "2022-11-01",
-        "do_not_delete": True,
         "soma": {
             "uri": "s3://cellxgene-data-public/cell-census/2022-11-01/soma/",
             "s3_region": "us-west-2",

--- a/api/python/cellxgene_census/tests/test_directory.py
+++ b/api/python/cellxgene_census/tests/test_directory.py
@@ -186,3 +186,17 @@ def test_live_directory_contents() -> None:
 
         assert fs.exists(version_description["soma"]["uri"])
         assert fs.exists(version_description["h5ads"]["uri"])
+
+
+def test_census_version_types() -> None:
+    """Do a little bit of runtime type checking on the results of census version functions.
+
+    Part of solving: https://github.com/chanzuckerberg/cellxgene-census/issues/1204
+    """
+    from cellxgene_census._release_directory import CensusVersionDescription
+
+    directory = cellxgene_census.get_census_version_directory()
+    for k, v in directory.items():
+        assert set(v).issubset(CensusVersionDescription.__annotations__)
+        desc = cellxgene_census.get_census_version_description(k)
+        assert set(desc).issubset(CensusVersionDescription.__annotations__)


### PR DESCRIPTION
Fixes #1204