### PR TITLE
[python] Reintroduce embeddings tests

### DIFF
--- a/api/python/cellxgene_census/tests/conftest.py
+++ b/api/python/cellxgene_census/tests/conftest.py
@@ -68,3 +68,11 @@ def lts_census() -> soma.Collection:
     import cellxgene_census
 
     return cellxgene_census.open_soma(census_version="stable")
+
+
+@pytest.fixture(scope="session")
+def dec_lts_census() -> soma.Collection:
+    """Fixture for the 2023-12-15 LTS Census."""
+    import cellxgene_census
+
+    return cellxgene_census.open_soma(census_version="2023-12-15")

--- a/api/python/cellxgene_census/tests/conftest.py
+++ b/api/python/cellxgene_census/tests/conftest.py
@@ -67,4 +67,4 @@ def census() -> soma.Collection:
 def lts_census() -> soma.Collection:
     import cellxgene_census
 
-    return cellxgene_census.open_soma(census_version="2023-12-15")
+    return cellxgene_census.open_soma(census_version="stable")

--- a/api/python/cellxgene_census/tests/experimental/test_embeddings.py
+++ b/api/python/cellxgene_census/tests/experimental/test_embeddings.py
@@ -77,10 +77,6 @@ def test_get_embedding_metadata_by_name(requests_mock: rm.Mocker) -> None:
         )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Current stable release doesn't have embeddings available. This xfail should be removed once that's resolved.",
-)
 def test_get_embedding_by_name_w_version_aliases() -> None:
     """https://github.com/chanzuckerberg/cellxgene-census/issues/1202"""
     # Only testing "stable" as "latest" doesn't have embeddings

--- a/api/python/cellxgene_census/tests/test_get_anndata.py
+++ b/api/python/cellxgene_census/tests/test_get_anndata.py
@@ -195,7 +195,7 @@ def test_get_anndata_obs_embeddings(lts_census: soma.Collection, obs_embeddings:
         obs_embeddings=obs_embeddings,
     )
 
-    assert len(ad.obsm.keys()) == 3
+    assert len(ad.obsm.keys()) == 2
     assert len(ad.varm.keys()) == 0
     for obsm_layer in obs_embeddings:
         assert obsm_layer in ad.obsm.keys()

--- a/api/python/cellxgene_census/tests/test_get_anndata.py
+++ b/api/python/cellxgene_census/tests/test_get_anndata.py
@@ -146,11 +146,11 @@ def test_get_anndata_wrong_layer_names(census: soma.Collection) -> None:
 
 @pytest.mark.live_corpus
 @pytest.mark.parametrize("obsm_layer", ["scvi", "geneformer"])
-def test_get_anndata_obsm_one_layer(lts_census: soma.Collection, obsm_layer: str) -> None:
-    # NOTE: this test will break after next LTS release (>2023-12-15), since scvi and geneformer
-    # won't be distributed as part of `obsm_layers` anymore. Delete this test when it happens.
+def test_get_anndata_obsm_one_layer(dec_lts_census: soma.Collection, obsm_layer: str) -> None:
+    # NOTE: This test only works on the 2023-12-15 LTS Census, since in newer releases
+    # the embeddings aren't distributed via the `obsm_layer` parameter.
     ad = cellxgene_census.get_anndata(
-        lts_census,
+        dec_lts_census,
         organism="Homo sapiens",
         X_name="raw",
         obs_coords=slice(100),
@@ -165,11 +165,11 @@ def test_get_anndata_obsm_one_layer(lts_census: soma.Collection, obsm_layer: str
 
 @pytest.mark.live_corpus
 @pytest.mark.parametrize("obsm_layers", [["scvi", "geneformer"]])
-def test_get_anndata_obsm_two_layers(lts_census: soma.Collection, obsm_layers: List[str]) -> None:
-    # NOTE: this test will break after next LTS release (>2023-12-15), since scvi and geneformer
-    # won't be distributed as part of `obsm_layers` anymore. Delete this test when it happens.
+def test_get_anndata_obsm_two_layers(dec_lts_census: soma.Collection, obsm_layers: List[str]) -> None:
+    # NOTE: This test only works on the 2023-12-15 LTS Census, since in newer releases
+    # the embeddings aren't distributed via the `obsm_layer` parameter.
     ad = cellxgene_census.get_anndata(
-        lts_census,
+        dec_lts_census,
         organism="Homo sapiens",
         X_name="raw",
         obs_coords=slice(100),
@@ -184,10 +184,8 @@ def test_get_anndata_obsm_two_layers(lts_census: soma.Collection, obsm_layers: L
 
 
 @pytest.mark.live_corpus
-@pytest.mark.parametrize("obs_embeddings", [["scvi", "geneformer", "uce"]])
+@pytest.mark.parametrize("obs_embeddings", [["scvi", "scgpt"]])
 def test_get_anndata_obs_embeddings(lts_census: soma.Collection, obs_embeddings: List[str]) -> None:
-    # NOTE: when the next LTS gets released (>2023-12-15), embeddings may or may not be available,
-    # so this test could require adjustments.
     ad = cellxgene_census.get_anndata(
         lts_census,
         organism="Homo sapiens",
@@ -206,12 +204,12 @@ def test_get_anndata_obs_embeddings(lts_census: soma.Collection, obs_embeddings:
 
 @pytest.mark.live_corpus
 @pytest.mark.parametrize("var_embeddings", [["nmf"]])
-def test_get_anndata_var_embeddings(lts_census: soma.Collection, var_embeddings: List[str]) -> None:
-    # NOTE: when the next LTS gets released (>2023-12-15), embeddings may or may not be available,
-    # so this test could require adjustments.
+def test_get_anndata_var_embeddings(dec_lts_census: soma.Collection, var_embeddings: List[str]) -> None:
+    # NOTE: this test only works on the 2023-12-15 LTS Census, since var embeddings
+    # aren't available in the newer releases.
 
     ad = cellxgene_census.get_anndata(
-        lts_census,
+        dec_lts_census,
         organism="Homo sapiens",
         X_name="raw",
         obs_coords=slice(100),


### PR DESCRIPTION
Tests were adapted to account for temporary lack of embeddings in the new LTS. Now that they have been published, tests can be reintroduced.