### PR TITLE
Move geneformer test dependency back to requirements-dev.txt

### DIFF
--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -44,10 +44,6 @@ jobs:
           pip install --use-pep517 accumulation-tree # Geneformer dependency needs --use-pep517 for Cython
           GIT_CLONE_PROTECTION_ACTIVE=false pip install -r ./api/python/cellxgene_census/scripts/requirements-dev.txt
           pip install -e './api/python/cellxgene_census/[experimental]'
-      - name: Install Geneformer (python >=3.10 only)
-        # Geneformer version should match that specified in api/python/cellxgene_census/src/cellxgene_census/experimental/ml/huggingface/geneformer_tokenizer.py
-        run: pip install git+https://huggingface.co/ctheodoris/Geneformer@57f02a4
-        if: matrix.python-version != '3.8' && matrix.python-version != '3.9'
       - name: Report Dependency Versions
         run: pip list
       - name: Test with pytest (API, main tests)

--- a/api/python/cellxgene_census/scripts/requirements-dev.txt
+++ b/api/python/cellxgene_census/scripts/requirements-dev.txt
@@ -5,5 +5,6 @@ twine
 coverage
 nbqa
 transformers[torch]
+git+https://huggingface.co/ctheodoris/Geneformer@471eefc; python_version>='3.10'
 owlready2
 proxy.py


### PR DESCRIPTION
This makes the dep available for all CI runs, and makes it available locally for running tests.

cc: @ebezzi @mlin