### PR TITLE
Pin census release version used in test

### DIFF
--- a/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
+++ b/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
@@ -246,7 +246,7 @@ def test_hvg_error_cases(small_mem_context: soma.SOMATileDBContext) -> None:
         with census["census_data"]["mus_musculus"].axis_query(measurement_name="RNA") as query:
             # Only flavor="seurat_v3" is supported
             with pytest.raises(ValueError):
-                highly_variable_genes(query, flavor="oopsie")
+                highly_variable_genes(query, flavor="oopsie")  # type: ignore[arg-type]
 
 
 @pytest.mark.experimental

--- a/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
+++ b/api/python/cellxgene_census/tests/experimental/pp/test_hvg.py
@@ -224,7 +224,7 @@ def test_get_highly_variable_genes(
     small_mem_context: soma.SOMATileDBContext,
     obs_coords: slice | None,
 ) -> None:
-    with cellxgene_census.open_soma(census_version="stable", context=small_mem_context) as census:
+    with cellxgene_census.open_soma(census_version="2023-12-15", context=small_mem_context) as census:
         hvg = get_highly_variable_genes(
             census,
             organism=organism,
@@ -246,7 +246,7 @@ def test_hvg_error_cases(small_mem_context: soma.SOMATileDBContext) -> None:
         with census["census_data"]["mus_musculus"].axis_query(measurement_name="RNA") as query:
             # Only flavor="seurat_v3" is supported
             with pytest.raises(ValueError):
-                highly_variable_genes(query, flavor="oopsie")  # type: ignore[arg-type]
+                highly_variable_genes(query, flavor="oopsie")
 
 
 @pytest.mark.experimental


### PR DESCRIPTION
https://github.com/chanzuckerberg/cellxgene-census/actions/runs/9882376259/job/27295103088


The test failure on the full tests is due to the new LTS.  The test uses both `value_filter` and `coords` on stable, but now that ends selecting 0 cells. I think we should probably just pin this test to a specific LTS release.

```python
census["census_data"]["mus_musculus"].axis_query(
    measurement_name="RNA",
    obs_query=tiledbsoma.AxisQuery(value_filter="is_primary_data == True", coords=(slice(750_000, 1_000_000),)),
).to_anndata(X_name="raw").shape
# (0, 52437)
```

Starting another test run on this branch: https://github.com/chanzuckerberg/cellxgene-census/actions/runs/9899971112