### PR TITLE
[python] Remove owlready2 dev dep

### DIFF
--- a/api/python/cellxgene_census/scripts/requirements-dev.txt
+++ b/api/python/cellxgene_census/scripts/requirements-dev.txt
@@ -6,5 +6,4 @@ coverage
 nbqa
 transformers[torch]
 git+https://huggingface.co/ctheodoris/Geneformer@471eefc; python_version>='3.10'
-owlready2
 proxy.py


### PR DESCRIPTION
`owlready2` is causing CI failures for python 3.8 and 3.9 since there's no wheel, and building from source fails.

It also looks like it's not actually necessary for the API tests (from local running), so I've just removed it here.