### PR TITLE
Fix LTS compat tests

### DIFF
--- a/.github/workflows/lts-compat-check.yml
+++ b/.github/workflows/lts-compat-check.yml
@@ -20,14 +20,14 @@ jobs:
         census-build-version:  # Add additional LTS releases as they occur
           - "latest"
           - "stable"
+          - "2024-07-01"
           - "2023-12-15"
           - "2023-07-25"
           - "2023-05-15"
         py-pkg-version:
-          - "~=1.10.0"
-          - "~=1.11.0"
-          - "~=1.12.0"
-          - "~=1.13.0"
+          - "~=1.14.0"
+          - "~=1.15.0"
+          - "~=1.16.0"
           - "head-of-main"
 
     runs-on: ${{matrix.os}}
@@ -43,12 +43,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip setuptools wheel
-          GIT_CLONE_PROTECTION_ACTIVE=false pip install -r ./api/python/cellxgene_census/scripts/requirements-dev.txt
 
           if [ ${{matrix.py-pkg-version}} == "head-of-main" ]; then
-            pip install -e ./api/python/cellxgene_census/
+            pip install -e ./api/python/cellxgene_census/ -r ./api/python/cellxgene_census/scripts/requirements-dev.txt
           else
-            pip install -U cellxgene_census${{ matrix.py-pkg-version }}
+            pip install -U cellxgene_census${{ matrix.py-pkg-version }} -r ./api/python/cellxgene_census/scripts/requirements-dev.txt
           fi
 
       - name: Test with pytest (API, main tests)


### PR DESCRIPTION
LTS compatibility tests have been failing for the past four months. I believe this is mostly due to uninstallable dependencies for old very old versions of the package.

Checking here: https://github.com/chanzuckerberg/cellxgene-census/actions/runs/12661005585

Run with:

```
gh workflow run lts-compat-check.yml --ref ivirshup/fix-lts-compat-tests
```