### PR TITLE
Touch up of spatial release article

### DIFF
--- a/docs/articles/2025/20250117-spatial.md
+++ b/docs/articles/2025/20250117-spatial.md
@@ -7,7 +7,7 @@ The Census team is pleased to announce the release of Spatial data on Census!
 
 This has been a large joint effort between the Census team and TileDB to create an easy-to-use and backwards-compatible spatial schema that enables easy analysis with non-spatial and spatial data!
 
-This first release is a **beta release** with the ability to export all spatial data (10x Visium and Slideseq) from an `obs/var` query in `SpatialData`. The ability to export `SpatialData` with spatial-based filters, transforms, etc., is not supported and will be implemented in a future release.
+This first release is a **beta release** with the ability to export all spatial data (10x Visium and Slideseq) from an `obs/var` query to [`SpatialData`](https://spatialdata.scverse.org/). The ability to export `SpatialData` with spatial-based filters, transforms, etc., is not supported and will be implemented in a future release.
 
 ---
 
@@ -17,37 +17,37 @@ This first release is a **beta release** with the ability to export all spatial 
 
 ### Building Blocks
 
-#### **SOMAExperiment**
+#### **{class}`tiledbsoma.Experiment`**
 
 A collection encapsulating data from one or more single-cell datasets, with reserved attributes:
 
 | Field Name             | Field Description                                                                 |
 |-------------------------|-----------------------------------------------------------------------------------|
 | `obs`                  | A DataFrame for observation metadata                                             |
-| `ms`                   | A collection (`SOMAMeasurement`), with cell-by-gene data matrices and a gene metadata DataFrame |
+| `ms`                   | A collection (`Measurement`), with cell-by-gene data matrices and a gene metadata DataFrame |
 | **[NEW] `spatial`**    | A collection of `Scene` objects (see below)                                      |
 | **[NEW] `obs_spatial_presence`** | A DataFrame to map observations to `Scene` objects                              |
 
 ---
 
-#### **[NEW] SOMAScene**
+#### **[NEW] {class}`tiledbsoma.Scene`**
 
 A collection of spatial assets. All assets in one `Scene` should correspond to the same physical coordinate system. The collection provides operations for getting, setting, and transforming between coordinate systems, with reserved attributes:
 
 | Field Name   | Field Description                                                                                                                                   |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `obsl`       | A collection of spatial arrays and collections. The rows in these arrays correspond to observations and may correspond to `obs` of a `SOMAExperiment`. |
-| `varl`       | A collection of collections for spatial arrays on the `SOMAMeasurements`. The top-level collection is indexed by measurement name. The rows in the contained arrays correspond to features and may correspond to `var` of the associated `SOMAMeasurement`. |
-| `img`        | A `SOMAImageCollection` of images (single and multi-resolution).                                                                                    |
+| `obsl`       | A collection of spatial arrays and collections. The rows in these arrays correspond to observations and may correspond to `obs` of an `Experiment`. |
+| `varl`       | A collection of collections for spatial arrays on the `Measurement`s. The top-level collection is indexed by measurement name. The rows in the contained arrays correspond to features and may correspond to `var` of the associated `Measurement`. |
+| `img`        | A `Collection` of `MultiscaleImage`s                                                        |
 
 ---
 
-#### **[NEW] SOMAImageCollection**
+#### **[NEW] {class}`tiledbsoma.MultiscaleImage`**
 
-A group of multi-resolution images that can be accessed by levels. Below are some sample operations on this collection type. Every `SOMAImageNDArray` in the collection must be mappable to the same physical space by translation and scaling only.
+A group of multi-resolution images that can be accessed by levels. Below are some sample operations on this collection type. Every  {class}`~tiledbsoma.DenseNDArray` in the collection must be mappable to the same physical space by scaling only.
 
 | Operation         | Description                                                             |
 |-------------------|-------------------------------------------------------------------------|
-| `levels`          | Sequence of level numbers in the slide                                 |
-| `dimensions`      | A `(width, height)` tuple for level 0 of the slide                     |
-| `level_dimensions`| A sequence of down-sample factors for each level of the slide          |
+| `.levels()`       | Returns a mapping of `{member_name: (uri, shape)}`.                    |
+| {attr}`~tiledbsoma.MultiscaleImage.coordinate_space` | Coordinate space for the base level of this `MultiscaleImage`    |
+| {obj}`~tiledbsoma.MultiscaleImage.get_transform_to_level` / {obj}`~tiledbsoma.MultiscaleImage.get_transform_from_level` | Get `ScaleTransform` to and from specified level to base level of image |

--- a/docs/articles/2025/20250117-spatial.md
+++ b/docs/articles/2025/20250117-spatial.md
@@ -7,7 +7,7 @@ The Census team is pleased to announce the release of Spatial data on Census!
 
 This has been a large joint effort between the Census team and TileDB to create an easy-to-use and backwards-compatible spatial schema that enables easy analysis with non-spatial and spatial data!
 
-This first release is a **beta release** with the ability to export all spatial data (10x Visium and Slideseq) from an `obs/var` query to [`SpatialData`](https://spatialdata.scverse.org/). The ability to export `SpatialData` with spatial-based filters, transforms, etc., is not supported and will be implemented in a future release.
+This first release is a **beta release** with the ability to export all spatial data (10x Visium and Slideseq) from an `obs/var` query to {class}`~spatialdata.SpatialData` ([spatialdata.scverse.org](https://spatialdata.scverse.org/en/stable/)). The ability to export `SpatialData` with spatial-based filters, transforms, etc., is not supported and will be implemented in a future release.
 
 ---
 

--- a/docs/articles/2025/20250117-spatial.md
+++ b/docs/articles/2025/20250117-spatial.md
@@ -7,7 +7,7 @@ The Census team is pleased to announce the release of Spatial data on Census!
 
 This has been a large joint effort between the Census team and TileDB to create an easy-to-use and backwards-compatible spatial schema that enables easy analysis with non-spatial and spatial data!
 
-This first release is a **beta release** with the ability to export all spatial data (10x Visium and Slideseq) from an `obs/var` query to {class}`~spatialdata.SpatialData` ([spatialdata.scverse.org](https://spatialdata.scverse.org/en/stable/)). The ability to export `SpatialData` with spatial-based filters, transforms, etc., is not supported and will be implemented in a future release.
+This first release is a **beta release** with the ability to export all spatial data (10x Visium Spatial Gene Expression and Slide-seqV2) from an `obs/var` query to {class}`~spatialdata.SpatialData` ([spatialdata.scverse.org](https://spatialdata.scverse.org/en/stable/)). The ability to query census with spatial-based filters, transforms, etc., is not supported and will be implemented in a future release.
 
 ---
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,7 @@ intersphinx_mapping = {
     'numpy': ('http://docs.scipy.org/doc/numpy', None),
     'scipy': ('http://docs.scipy.org/doc/scipy/reference', None),
     'anndata': ('https://anndata.readthedocs.io/en/latest/', None),
+    'spatialdata': ("https://spatialdata.scverse.org/en/stable/", None),
     'pandas': ('https://pandas.pydata.org/docs/', None),
     'scanpy': ('https://scanpy.readthedocs.io/en/stable/', None),
     'torch': ('https://pytorch.org/docs/stable/', None),


### PR DESCRIPTION
* Added links to relevant `tiledbsoma` and `spatialdata` doc pages
* Fixed outdated image documentation

This looks like:

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/2df69b2d-4604-479d-a75c-4ac5c82b0325" />

Where the bolded code titles link to the tiledbsoma documentation.

* `.levels()` is not currently documented, but was on the original set of attributes to document. I will check in with tiledb on this
