### PR TITLE
fix: Update runs-on labels in GitHub Actions workflows

### DIFF
--- a/.github/workflows/py-build.yml
+++ b/.github/workflows/py-build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build_python_wheels:
     name: Build Python wheel and sdist
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: X64
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
 
   build_docker_container:
     name: Build Docker image for Census Builder
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: X64
     permissions: # these permissions must be set for AWS auth to work!
       id-token: write
       contents: read

--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -100,7 +100,7 @@ jobs:
     needs:
       - unit_tests_builder
       - unit_tests_python_api
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: X64
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
https://czi.atlassian.net/browse/CCIE-3911

This PR updates 'runs-on' in GitHub Actions workflow files to use direct values instead of label arrays.