### PR TITLE
Try using new managed runners

### DIFF
--- a/.github/workflows/docsite-build-deploy.yml
+++ b/.github/workflows/docsite-build-deploy.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build-and-deploy:
     concurrency: ci-${{ github.ref }}
-    runs-on: sc-dev-64g-runner
+    runs-on: x64
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4

--- a/.github/workflows/full-unittests.yml
+++ b/.github/workflows/full-unittests.yml
@@ -42,7 +42,7 @@ env:
 
 jobs:
   py_unit_tests:
-    runs-on: sc-dev-64g-runner
+    runs-on: x64
     timeout-minutes: 1440 # 24 hour timeout
     strategy:
       fail-fast: false # prevent this job from killing other jobs
@@ -88,7 +88,7 @@ jobs:
           PYTHONPATH=. pytest -v --durations=0 -rP --experimental --expensive ./api/python/cellxgene_census/tests/
 
   r_unit_tests:
-    runs-on: sc-dev-64g-runner
+    runs-on: x64
     timeout-minutes: 1440 # 24 hour timeout
     strategy:
       fail-fast: false # prevent this job from killing other jobs

--- a/.github/workflows/profiler.yml
+++ b/.github/workflows/profiler.yml
@@ -12,7 +12,7 @@ jobs:
     name: Run Profiler
     strategy:
       matrix:
-        os: [sc-dev-64g-runner]
+        os: [x64]
         python-version: ["3.11"]
     runs-on: ${{matrix.os}}
     permissions: # these permissions must be set for AWS auth to work!

--- a/.github/workflows/py-build.yml
+++ b/.github/workflows/py-build.yml
@@ -39,7 +39,7 @@ jobs:
 
   build_docker_container:
     name: Build Docker image for Census Builder
-    runs-on: X64
+    runs-on: x64-privileged  # Docker builds require privileged container
     permissions: # these permissions must be set for AWS auth to work!
       id-token: write
       contents: read

--- a/.github/workflows/py-dependency-check.yml
+++ b/.github/workflows/py-dependency-check.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false  # don't fail-fast, as errors are often specific to a single cell in the matrix
       matrix:
-        os: [sc-dev-64g-runner, macos-latest]
+        os: [x64, macos-latest]
         python-version: ["3.10", "3.11", "3.12"]
         exclude:
           - os: macos-latest
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: install tooling
-        if: matrix.os == 'sc-dev-64g-runner'
+        if: matrix.os == 'x64'
         run: |
           sudo apt-get update && sudo apt-get install -y jq
 

--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -69,7 +69,7 @@ jobs:
   unit_tests_builder:
     strategy:
       matrix:
-        os: [x64-xl-privileged]
+        os: [x64]
         python-version: ["3.11"]
 
     runs-on: ${{matrix.os}}

--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false  # Don't stop the workflow if one of the jobs fails
       matrix:
-        os: [sc-dev-64g-runner, macos-latest]
+        os: [x64, macos-latest]
         python-version: ["3.10", "3.11", "3.12"]
         exclude:
           - os: macos-latest

--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false  # Don't stop the workflow if one of the jobs fails
       matrix:
-        os: [x64, macos-latest]
+        os: [x64-xl-privileged, macos-latest]
         python-version: ["3.10", "3.11", "3.12"]
         exclude:
           - os: macos-latest
@@ -39,7 +39,7 @@ jobs:
             api/**/pyproject.toml
             api/**/requirements*.txt
       - name: Install git-lfs (Linux)
-        if: matrix.os == 'x64'
+        if: matrix.os == 'x64-xl-privileged'
         run: |
           sudo apt-get update
           sudo apt-get install git-lfs
@@ -69,7 +69,7 @@ jobs:
   unit_tests_builder:
     strategy:
       matrix:
-        os: [x64]
+        os: [x64-xl-privileged]
         python-version: ["3.11"]
 
     runs-on: ${{matrix.os}}

--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -39,7 +39,7 @@ jobs:
             api/**/pyproject.toml
             api/**/requirements*.txt
       - name: Install git-lfs (Linux)
-        if: matrix.os == 'sc-dev-64g-runner'
+        if: matrix.os == 'x64'
         run: |
           sudo apt-get update
           sudo apt-get install git-lfs
@@ -69,7 +69,7 @@ jobs:
   unit_tests_builder:
     strategy:
       matrix:
-        os: [sc-dev-64g-runner]
+        os: [x64]
         python-version: ["3.11"]
 
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
Our self-hosted runners seem busted. In this PR I am attempting to switch over to some more centrally managed runners. 