### PR TITLE
Remove summarized donor count from docs and builds

### DIFF
--- a/api/python/notebooks/analysis_demo/comp_bio_census_info.ipynb
+++ b/api/python/notebooks/analysis_demo/comp_bio_census_info.ipynb
@@ -364,7 +364,6 @@
     "\n",
     "- `total_cell_count` is the total number of cells in the Census.\n",
     "- `unique_cell_count` is the number of unique cells, as some cells may be present twice due to meta-analysis or consortia-like data.\n",
-    "- `number_donors_homo_sapiens` and `number_donors_mus_musculus` are the number of individuals for human and mouse. These are not guaranteed to be unique as one individual ID may be present or identical in different datasets.\n",
     "\n",
     "### Cell counts by cell metadata\n",
     "\n",

--- a/api/r/cellxgene.census/_vignettes/comp_bio_census_info.Rmd
+++ b/api/r/cellxgene.census/_vignettes/comp_bio_census_info.Rmd
@@ -108,7 +108,6 @@ Of special interest are the label-value combinations for:
 
 - `total_cell_count` is the total number of cells in the Census.
 - `unique_cell_count` is the number of unique cells, as some cells may be present twice due to meta-analysis or consortia-like data.
-- `number_donors_homo_sapiens` and `number_donors_mus_musculus` are the number of individuals for human and mouse. These are not guaranteed to be unique as one individual ID may be present or identical in different datasets.
 
 ### Cell counts by cell metadata
 

--- a/docs/cellxgene_census_schema.md
+++ b/docs/cellxgene_census_schema.md
@@ -204,12 +204,6 @@ This `SOMADataFrame` MUST have the following rows:
 5. Unique number of cells included in this Census build (is_primary_data == True)
    1. label: `"unique_cell_count"`
    2. value: Cell count
-6. Number of human donors included in this Census build. Donors are guaranteed to be unique within datasets, not across all Census.
-   1. label: `"number_donors_homo_sapiens"`
-   2. value: Donor count
-7. Number of mouse donors included in this Census build. Donors are guaranteed to be unique within datasets, not across all Census.
-   1. label: `"number_donors_mus_musculus"`
-   2. value: Donor count
 
 An example of this `SOMADataFrame` is shown below:
 
@@ -240,14 +234,6 @@ An example of this `SOMADataFrame` is shown below:
   <tr>
     <td>unique_cell_count</td>
     <td>1000</td>
-  </tr>
-  <tr>
-    <td>number_donors_homo_sapiens</td>
-    <td>100</td>
-  </tr>
-  <tr>
-    <td>number_donors_mus_musculus</td>
-    <td>100</td>
   </tr>
 </tbody>
 </table>

--- a/docs/cellxgene_census_schema.md
+++ b/docs/cellxgene_census_schema.md
@@ -860,6 +860,10 @@ Cell metadata MUST be encoded as a `SOMADataFrame` with the following columns:
 
 ## Changelog
 
+### Version 2.X.1
+
+* Removed fields `number_donors_homo_sapiens` and `number_donors_mus_musculus` from `census_obj​​["census_info"]["summary"]` as we cannot correctly count donors across datasets.
+
 ### Version 2.2.0
 
 * Allow organoid data, i.e. `tissue_type` can now be `organoid` other than `tissue`.

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/census_summary.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/census_summary.py
@@ -23,8 +23,6 @@ def create_census_summary(
         ("dataset_schema_version", CXG_SCHEMA_VERSION),
         ("total_cell_count", str(summary_stats["total_cell_count"])),
         ("unique_cell_count", str(summary_stats["unique_cell_count"])),
-        ("number_donors_homo_sapiens", str(summary_stats["number_donors"]["homo_sapiens"])),
-        ("number_donors_mus_musculus", str(summary_stats["number_donors"]["mus_musculus"])),
     ]
 
     df = pd.DataFrame.from_records(data, columns=["label", "value"])

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/experiment_builder.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/experiment_builder.py
@@ -34,7 +34,6 @@ from .globals import (
     CENSUS_X_LAYERS,
     CENSUS_X_LAYERS_PLATFORM_CONFIG,
     CXG_VAR_COLUMNS_READ,
-    DONOR_ID_IGNORE,
     FEATURE_DATASET_PRESENCE_MATRIX_NAME,
     FULL_GENE_ASSAY,
     MEASUREMENT_RNA_NAME,
@@ -190,7 +189,6 @@ class ExperimentBuilder:
         self.n_unique_obs: int = 0
         self.n_var: int = 0
         self.n_datasets: int = 0
-        self.n_donors: int = 0  # Caution: defined as (unique dataset_id, donor_id) tuples, *excluding* some values
         self.obs_df: pd.DataFrame | None = None
         self.var_df: pd.DataFrame | None = None
         self.dataset_obs_joinid_start: dict[str, int] = {}  # starting joinid per dataset_id
@@ -456,7 +454,6 @@ def post_acc_axes_processing(accumulated: list[tuple[ExperimentBuilder, tuple[pd
         # compute intermediate values used later in the build
         eb.n_datasets = obs.dataset_id.nunique()
         eb.n_unique_obs = (obs.is_primary_data == True).sum()  # noqa: E712
-        eb.n_donors = obs[~obs.donor_id.isin(DONOR_ID_IGNORE)].groupby("dataset_id").donor_id.nunique().sum()
         eb.global_var_joinids = var[["feature_id", "soma_joinid"]].set_index("feature_id")
 
         grouped_by_id = obs.groupby("dataset_id").soma_joinid.agg(["min", "count"])
@@ -811,14 +808,12 @@ def populate_X_layers(
 class SummaryStats(TypedDict):
     total_cell_count: int
     unique_cell_count: int
-    number_donors: dict[str, int]
 
 
 def get_summary_stats(experiment_builders: Sequence[ExperimentBuilder]) -> SummaryStats:
     return {
         "total_cell_count": sum(e.n_obs for e in experiment_builders),
         "unique_cell_count": sum(e.n_unique_obs for e in experiment_builders),
-        "number_donors": {e.name: e.n_donors for e in experiment_builders},
     }
 
 

--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/globals.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/globals.py
@@ -10,6 +10,7 @@ from .schema_util import FieldSpec, TableSpec
 # DataFrame columns. True is enabled, False is disabled.
 USE_ARROW_DICTIONARY = True
 
+# TODO: BUMP THIS
 CENSUS_SCHEMA_VERSION = "2.1.0"
 
 CXG_SCHEMA_VERSION = "5.2.0"  # the CELLxGENE schema version supported
@@ -347,8 +348,6 @@ FULL_GENE_ASSAY = [
     "EFO:0030061",  # mcSCRB-seq
     "EFO:0700016",  # Smart-seq v4
 ]
-
-DONOR_ID_IGNORE = ["pooled", "unknown"]
 
 
 # The default configuration for TileDB contexts used in the builder.


### PR DESCRIPTION
Addressing part of https://github.com/chanzuckerberg/cellxgene-census/issues/1373

This PR removes the summarized donor counts fields from builds and docs.

It looks like we missed a bump on census version number, so that needs to be corrected. We also need to decide what level of version bump this change is.

We should also re-run notebooks to point at newer versions of census so that the fields don't show up when loading older versions.
