### PR TITLE
copy GeneformerTokenizer into tools/models/geneformer

### DIFF
--- a/tools/models/geneformer/Dockerfile
+++ b/tools/models/geneformer/Dockerfile
@@ -48,5 +48,5 @@ COPY helpers ./helpers
 COPY *.py ./
 COPY finetune-geneformer.config.yml .
 
-# run test_GeneformerTokenizer.py tests, which will exercise cellxgene_census/tiledbsoma, Geneformer, and helpers/
-RUN pytest -v
+# run GeneformerTokenizer unit tests, which will exercise cellxgene_census/tiledbsoma, Geneformer, and helpers/
+RUN pytest -v test_GeneformerTokenizer.py

--- a/tools/models/geneformer/Dockerfile
+++ b/tools/models/geneformer/Dockerfile
@@ -5,23 +5,29 @@
 # - our Census-Geneformer training scripts
 FROM nvcr.io/nvidia/cuda:11.8.0-runtime-ubuntu22.04
 
-RUN apt update && apt install -y build-essential python3-pip python3-venv git-lfs pigz libcurl4-openssl-dev
-RUN git lfs install
-
-ENV GIT_SSL_NO_VERIFY=true
-RUN pip install --upgrade pip setuptools setuptools_scm
-RUN pip install torch 'torchdata<0.10' --index-url https://download.pytorch.org/whl/cu118
-                                                                             # ^^^ match the base image CUDA version!
-RUN pip install owlready2 boto3 transformers[torch]
-# workaround for unknown problem blocking `import geneformer`:
-#   https://github.com/microsoft/TaskMatrix/issues/116#issuecomment-1565431850
-RUN pip uninstall -y transformer-engine
-
 # Set the tiledbsoma version used to write the embeddings SparseNDArray, to ensure
 # compatibility with the Census embeddings curator
 ARG EMBEDDINGS_TILEDBSOMA_VERSION=1.11.4
 ARG CELLXGENE_CENSUS_VERSION=main
 ARG GENEFORMER_VERSION=ebc1e096
+
+RUN apt update && apt install -y \
+        software-properties-common \
+        build-essential \
+        python3-pip python3-venv \
+        git-lfs \
+        pigz \
+        libcurl4-openssl-dev
+RUN git lfs install
+
+ENV GIT_SSL_NO_VERIFY=true
+RUN pip install --upgrade pip setuptools setuptools_scm pytest
+RUN pip install torch 'torchdata<0.10' --index-url https://download.pytorch.org/whl/cu118
+                                                                             # ^^^ match the base image CUDA version!
+RUN pip install owlready2 boto3 'transformers[torch]<4.50'
+# workaround for unknown problem blocking `import geneformer`:
+#   https://github.com/microsoft/TaskMatrix/issues/116#issuecomment-1565431850
+RUN pip uninstall -y transformer-engine
 
 RUN mkdir /census-geneformer
 WORKDIR /census-geneformer
@@ -32,9 +38,6 @@ RUN git clone --recursive https://huggingface.co/ctheodoris/Geneformer \
         && git -C Geneformer checkout ${GENEFORMER_VERSION}
 RUN pip install -e Geneformer
 
-# smoke test
-RUN python3 -c 'import geneformer; import cellxgene_census; from cellxgene_census.experimental.ml.huggingface import GeneformerTokenizer; cellxgene_census.open_soma()'
-
 # prepare a venv with pinned tiledbsoma ${EMBEDDINGS_TILEDBSOMA_VERSION}, which our embeddings
 # generation step will use to output a TileDB array compatible with the Census embeddings curator.
 RUN python3 -m venv --system-site-packages embeddings_tiledbsoma_venv && \
@@ -44,3 +47,6 @@ RUN python3 -m venv --system-site-packages embeddings_tiledbsoma_venv && \
 COPY helpers ./helpers
 COPY *.py ./
 COPY finetune-geneformer.config.yml .
+
+# run test_GeneformerTokenizer.py tests, which will exercise cellxgene_census/tiledbsoma, Geneformer, and helpers/
+RUN pytest -v

--- a/tools/models/geneformer/README.md
+++ b/tools/models/geneformer/README.md
@@ -14,7 +14,7 @@ The `Dockerfile` provides the recipe for the docker image used by the WDLs, whic
 
 ## Example invocations
 
-Using [miniwdl-omics-run](https://github.com/miniwdl-ext/miniwdl-omics-run) for the Amazon HealthOmics workflow service, and assuming the docker image has been built and pushed to ECR (tagged `$DOCKER_TAG`).
+Using [miniwdl-omics-run](https://github.com/miniwdl-ext/miniwdl-omics-run) for the Amazon HealthOmics workflow service, and assuming the docker image has been built and pushed to ECR (tagged `$DOCKER_TAG`).  It's probably easier to build the docker image on EC2 than your laptop, since it's >10GB and uses CPU instructions that aren't supported by Docker for Mac's x86-64 emulator.
 
 Preparing a tokenized dataset for all of Census (>500GB, sharded):
 

--- a/tools/models/geneformer/helpers/__init__.py
+++ b/tools/models/geneformer/helpers/__init__.py
@@ -1,0 +1,2 @@
+from .cell_dataset_builder import CellDatasetBuilder
+from .geneformer_tokenizer import GeneformerTokenizer

--- a/tools/models/geneformer/helpers/cell_dataset_builder.py
+++ b/tools/models/geneformer/helpers/cell_dataset_builder.py
@@ -1,0 +1,112 @@
+import uuid
+import warnings
+from abc import ABC, abstractmethod
+from collections.abc import Generator
+from typing import Any
+
+import scipy.sparse
+from tiledbsoma import Experiment, ExperimentAxisQuery
+
+
+class CellDatasetBuilder(ExperimentAxisQuery, ABC):  # type: ignore
+    """Abstract base class for methods to process CELLxGENE Census ExperimentAxisQuery
+    results into a Hugging Face Dataset in which each item represents one cell.
+    Subclasses implement the `cell_item()` method to process each row of an X layer
+    into a Dataset item, and may also override `__init__()` and context `__enter__()`
+    to perform any necessary preprocessing.
+
+    **DEPRECATION NOTICE:** this is planned for removal from the cellxgene_census API and
+    migrated into git:cellxgene-census/tools/models/geneformer.
+
+    The base class inherits ExperimentAxisQuery, so typical usage would be:
+
+    ```
+    import cellxgene_census
+    import tiledbsoma
+    from cellxgene_census.experimental.ml import GeneformerTokenizer
+
+    with cellxgene_census.open_soma() as census:
+        with SubclassOfCellDatasetBuilder(
+            census["census_data"]["homo_sapiens"],
+            obs_query=tilebsoma.AxisQuery(...),  # define some subset of Census cells
+            ... # other ExperimentAxisQuery parameters e.g. var_query
+        ) as builder:
+            dataset = builder.build()
+    ```
+    """
+
+    def __init__(
+        self,
+        experiment: Experiment,
+        measurement_name: str = "RNA",
+        layer_name: str = "raw",
+        *,
+        block_size: int | None = None,
+        **kwargs: Any,
+    ):
+        """Initialize the CellDatasetBuilder to process the results of a Census
+        ExperimentAxisQuery.
+
+        - `experiment`: Census Experiment to be queried.
+        - `measurement_name`: Measurement in the experiment, default "RNA".
+        - `layer_name`: Name of the X layer to process, default "raw".
+        - `block_size`: Number of cells to process in-memory at once. If unspecified,
+           `tiledbsoma.SparseNDArrayRead.blockwise()` will select a default.
+        - `kwargs`: passed through to `ExperimentAxisQuery()`, especially `obs_query`
+           and `var_query`.
+        """
+        super().__init__(experiment, measurement_name, **kwargs)
+        self.layer_name = layer_name
+        self.block_size = block_size
+        warnings.warn(
+            "cellxgene_census.experimental.ml.huggingface will be removed from API in an upcoming release and migrated to git:cellxgene-census/tools/models/geneformer",
+            FutureWarning,
+            stacklevel=2,
+        )
+
+    def build(self, from_generator_kwargs: dict[str, Any] | None = None) -> "Dataset":  # type: ignore  # noqa: F821
+        """Build the dataset from query results.
+
+        - `from_generator_kwargs`: kwargs passed through to `Dataset.from_generator()`
+        """
+        # late binding to simplify CI dependencies:
+        from datasets import Dataset
+
+        def gen() -> Generator[dict[str, Any], None, None]:
+            for Xblock, (block_cell_joinids, _) in (
+                self.X(self.layer_name).blockwise(axis=0, reindex_disable_on_axis=[1], size=self.block_size).scipy()
+            ):
+                assert isinstance(Xblock, scipy.sparse.csr_matrix)
+                assert Xblock.shape[0] == len(block_cell_joinids)
+                for i, cell_joinid in enumerate(block_cell_joinids):
+                    yield self.cell_item(cell_joinid, Xblock.getrow(i))
+
+        return Dataset.from_generator(_DatasetGeneratorPickleHack(gen), **(from_generator_kwargs or {}))
+
+    @abstractmethod
+    def cell_item(self, cell_joinid: int, Xrow: scipy.sparse.csr_matrix) -> dict[str, Any]:
+        """Abstract method to process the X row for one cell into a Dataset item.
+
+        - `cell_joinid`: The cell `soma_joinid`.
+        - `Xrow`: The `X` row for this cell. This csr_matrix has a single row 0, equal
+          to the `cell_joinid` row of the full `X` layer matrix.
+        """
+        ...
+
+
+class _DatasetGeneratorPickleHack:
+    """SEE: https://github.com/huggingface/datasets/issues/6194."""
+
+    def __init__(self, generator: Any, generator_id: str | None = None) -> None:
+        self.generator = generator
+        self.generator_id = generator_id if generator_id is not None else str(uuid.uuid4())
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self.generator(*args, **kwargs)
+
+    def __reduce__(self) -> Any:
+        return (_DatasetGeneratorPickleHack_raise, (self.generator_id,))
+
+
+def _DatasetGeneratorPickleHack_raise(*args: Any, **kwargs: Any) -> None:
+    raise AssertionError("cannot actually unpickle _DatasetGeneratorPickleHack!")

--- a/tools/models/geneformer/helpers/cell_dataset_builder.py
+++ b/tools/models/geneformer/helpers/cell_dataset_builder.py
@@ -1,5 +1,4 @@
 import uuid
-import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Generator
 from typing import Any
@@ -14,9 +13,6 @@ class CellDatasetBuilder(ExperimentAxisQuery, ABC):  # type: ignore
     Subclasses implement the `cell_item()` method to process each row of an X layer
     into a Dataset item, and may also override `__init__()` and context `__enter__()`
     to perform any necessary preprocessing.
-
-    **DEPRECATION NOTICE:** this is planned for removal from the cellxgene_census API and
-    migrated into git:cellxgene-census/tools/models/geneformer.
 
     The base class inherits ExperimentAxisQuery, so typical usage would be:
 
@@ -58,11 +54,6 @@ class CellDatasetBuilder(ExperimentAxisQuery, ABC):  # type: ignore
         super().__init__(experiment, measurement_name, **kwargs)
         self.layer_name = layer_name
         self.block_size = block_size
-        warnings.warn(
-            "cellxgene_census.experimental.ml.huggingface will be removed from API in an upcoming release and migrated to git:cellxgene-census/tools/models/geneformer",
-            FutureWarning,
-            stacklevel=2,
-        )
 
     def build(self, from_generator_kwargs: dict[str, Any] | None = None) -> "Dataset":  # type: ignore  # noqa: F821
         """Build the dataset from query results.

--- a/tools/models/geneformer/helpers/geneformer_tokenizer.py
+++ b/tools/models/geneformer/helpers/geneformer_tokenizer.py
@@ -1,0 +1,241 @@
+import pickle
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+import scipy
+import tiledbsoma
+
+from .cell_dataset_builder import CellDatasetBuilder
+
+
+class GeneformerTokenizer(CellDatasetBuilder):
+    """Generate a Hugging Face `Dataset` containing Geneformer token sequences for each
+    cell in CELLxGENE Census ExperimentAxisQuery results (human).
+
+    This class requires the Geneformer package to be installed separately with:
+    `pip install transformers[torch]<4.50 git+https://huggingface.co/ctheodoris/Geneformer@ebc1e096`
+
+    **DEPRECATION NOTICE:** this is planned for removal from the cellxgene_census API and
+    migrated into git:cellxgene-census/tools/models/geneformer.
+
+    Example usage:
+
+    ```
+    import cellxgene_census
+    import tiledbsoma
+    from cellxgene_census.experimental.ml.huggingface import GeneformerTokenizer
+
+    with cellxgene_census.open_soma(census_version="latest") as census:
+        with GeneformerTokenizer(
+            census["census_data"]["homo_sapiens"],
+            # set obs_query to define some subset of Census cells:
+            obs_query=tiledbsoma.AxisQuery(value_filter="is_primary_data == True and tissue_general == 'tongue'"),
+            obs_column_names=(
+                "soma_joinid",
+                "cell_type_ontology_term_id",
+            ),
+        ) as tokenizer:
+            dataset = tokenizer.build()
+    ```
+
+    Dataset item contents:
+    - `input_ids`: Geneformer token sequence for the cell
+    - `length`: Length of the token sequence
+    - and the specified `obs_column_names` (cell metadata from the experiment obs dataframe)
+    """
+
+    obs_column_names: set[str]
+    max_input_tokens: int
+    special_token: bool
+
+    # Newer versions of Geneformer has a consolidated gene list (gene_mapping_file), meaning the
+    # counts for one or more Census genes are to be summed to get the count for one Geneformer
+    # gene. model_gene_map is a sparse binary matrix to map a cell vector (or multi-cell matrix) of
+    # Census gene counts onto Geneformer gene counts. model_gene_map[i,j] is 1 iff the i'th Census
+    # gene count contributes to the j'th Geneformer gene count.
+    model_gene_map: scipy.sparse.coo_matrix
+    model_gene_tokens: npt.NDArray[np.int64]  # Geneformer token for each column of model_gene_map
+    model_gene_medians: npt.NDArray[np.float64]  # float for each column of model_gene_map
+    model_cls_token: np.int64 | None = None
+    model_eos_token: np.int64 | None = None
+
+    def __init__(
+        self,
+        experiment: tiledbsoma.Experiment,
+        *,
+        obs_column_names: Sequence[str] | None = None,
+        obs_attributes: Sequence[str] | None = None,
+        max_input_tokens: int = 4096,
+        special_token: bool = True,
+        token_dictionary_file: str = "",
+        gene_median_file: str = "",
+        gene_mapping_file: str = "",
+        **kwargs: Any,
+    ) -> None:
+        """Initialize GeneformerTokenizer.
+
+        Args:
+        - `experiment`: Census Experiment to query
+        - `obs_query`: obs AxisQuery defining the set of Census cells to process (default all)
+        - `obs_column_names`: obs dataframe columns (cell metadata) to propagate into attributes
+           of each Dataset item
+        - `max_input_tokens`: maximum length of Geneformer input token sequence (default 4096)
+        - `special_token`: whether to affix separator tokens to the sequence (default True)
+        - `token_dictionary_file`, `gene_median_file`: pickle files supplying the mapping of
+          Ensembl human gene IDs onto Geneformer token numbers and median expression values.
+          By default, these will be loaded from the Geneformer package.
+        - `gene_mapping_file`: optional pickle file with mapping for Census gene IDs to model's
+        """
+        if obs_attributes:  # old name of obs_column_names
+            obs_column_names = obs_attributes
+
+        self.max_input_tokens = max_input_tokens
+        self.special_token = special_token
+        self.obs_column_names = set(obs_column_names) if obs_column_names else set()
+        self._load_geneformer_data(experiment, token_dictionary_file, gene_median_file, gene_mapping_file)
+        super().__init__(
+            experiment,
+            measurement_name="RNA",
+            layer_name="raw",
+            **kwargs,
+        )
+
+    def _load_geneformer_data(
+        self,
+        experiment: tiledbsoma.Experiment,
+        token_dictionary_file: str,
+        gene_median_file: str,
+        gene_mapping_file: str,
+    ) -> None:
+        """Load (1) the experiment's genes dataframe and (2) Geneformer's static data
+        files for gene tokens and median expression; then, intersect them to compute
+        self.model_gene_{ids,tokens,medians}.
+        """
+        # TODO: this work could be reused for all queries on this experiment
+
+        genes_df = (
+            experiment.ms["RNA"]
+            .var.read(column_names=["soma_joinid", "feature_id"])
+            .concat()
+            .to_pandas()
+            .set_index("soma_joinid")
+        )
+
+        if not (token_dictionary_file and gene_median_file and gene_mapping_file):
+            try:
+                import geneformer
+            except ImportError:
+                # pyproject.toml can't express Geneformer git+https dependency
+                raise ImportError(
+                    "Please install Geneformer with: "
+                    "pip install transformers[torch]<4.50 git+https://huggingface.co/ctheodoris/Geneformer@ebc1e096"
+                ) from None
+            if not token_dictionary_file:
+                token_dictionary_file = geneformer.tokenizer.TOKEN_DICTIONARY_FILE
+            if not gene_median_file:
+                gene_median_file = geneformer.tokenizer.GENE_MEDIAN_FILE
+            if not gene_mapping_file:
+                gene_mapping_file = geneformer.tokenizer.ENSEMBL_MAPPING_FILE
+        with open(token_dictionary_file, "rb") as f:
+            gene_token_dict = pickle.load(f)
+        with open(gene_median_file, "rb") as f:
+            gene_median_dict = pickle.load(f)
+
+        gene_mapping = None
+        if gene_mapping_file:
+            with open(gene_mapping_file, "rb") as f:
+                gene_mapping = pickle.load(f)
+
+        # compute model_gene_{ids,tokens,medians} by joining genes_df with Geneformer's
+        # dicts
+        map_data = []
+        map_i = []
+        map_j = []
+        model_gene_id_by_ensg: dict[str, int] = {}
+        model_gene_count = 0
+        model_gene_tokens: list[np.int64] = []
+        model_gene_medians: list[np.float64] = []
+        for gene_id, row in genes_df.iterrows():
+            ensg = row["feature_id"]  # ENSG... gene id, which keys Geneformer's dicts
+            if gene_mapping is not None:
+                ensg = gene_mapping.get(ensg, ensg)
+            if ensg in gene_token_dict:
+                if ensg not in model_gene_id_by_ensg:
+                    model_gene_id_by_ensg[ensg] = model_gene_count
+                    model_gene_count += 1
+                    model_gene_tokens.append(gene_token_dict[ensg])
+                    model_gene_medians.append(gene_median_dict[ensg])
+                map_data.append(1)
+                map_i.append(gene_id)
+                map_j.append(model_gene_id_by_ensg[ensg])
+
+        self.model_gene_map = scipy.sparse.coo_matrix(
+            (map_data, (map_i, map_j)), shape=(genes_df.index.max() + 1, model_gene_count), dtype=bool
+        )
+        self.model_gene_tokens = np.array(model_gene_tokens, dtype=np.int64)
+        self.model_gene_medians = np.array(model_gene_medians, dtype=np.float64)
+
+        assert len(np.unique(self.model_gene_tokens)) == len(self.model_gene_tokens)
+        assert np.all(self.model_gene_medians > 0)
+        # Geneformer models protein-coding and miRNA genes, so the intersection should
+        # be north of 18K.
+        assert (
+            model_gene_count > 18_000
+        ), f"Mismatch between Census gene IDs and Geneformer token dicts (only {model_gene_count} common genes)"
+
+        # Precompute a vector by which we'll multiply each cell's expression vector.
+        # The denominator normalizes by Geneformer's median expression values.
+        # The numerator 10K factor follows Geneformer's tokenizer; theoretically it doesn't affect
+        # affect the rank order, but is probably intended to help with numerical precision.
+        self.model_gene_medians_factor = 10_000.0 / self.model_gene_medians
+
+        if self.special_token:
+            self.model_cls_token = gene_token_dict["<cls>"]
+            self.model_eos_token = gene_token_dict["<eos>"]
+
+    def __enter__(self) -> "GeneformerTokenizer":
+        super().__enter__()
+        # On context entry, load the necessary cell metadata (obs_df)
+        obs_column_names = list(self.obs_column_names)
+        if "soma_joinid" not in self.obs_column_names:
+            obs_column_names.append("soma_joinid")
+        self.obs_df = self.obs(column_names=obs_column_names).concat().to_pandas().set_index("soma_joinid")
+        return self
+
+    def cell_item(self, cell_joinid: int, cell_Xrow: scipy.sparse.csr_matrix) -> dict[str, Any]:
+        """Given the expression vector for one cell, compute the Dataset item providing
+        the Geneformer inputs (token sequence and metadata).
+        """
+        # Apply model_gene_map to cell_Xrow and normalize with row sum & gene medians.
+        # Notice we divide by the total count of the complete row (not only of the projected
+        # values); this follows Geneformer's internal tokenizer.
+        model_expr = (cell_Xrow * self.model_gene_map).multiply(self.model_gene_medians_factor / cell_Xrow.sum())
+        assert isinstance(model_expr, scipy.sparse.coo_matrix), type(model_expr)
+        assert model_expr.shape == (1, self.model_gene_map.shape[1])
+
+        # figure the resulting tokens in descending order of model_expr
+        # (use sparse model_expr.{col,data} to naturally exclude undetected genes)
+        token_order = model_expr.col[np.argsort(-model_expr.data)[: self.max_input_tokens]]
+        input_ids = self.model_gene_tokens[token_order]
+
+        if self.special_token:
+            # affix special tokens, dropping the last two gene tokens if necessary
+            if len(input_ids) == self.max_input_tokens:
+                input_ids = input_ids[:-1]
+            assert self.model_cls_token is not None
+            input_ids = np.insert(input_ids, 0, self.model_cls_token)
+            if len(input_ids) == self.max_input_tokens:
+                input_ids = input_ids[:-1]
+            assert self.model_eos_token is not None
+            input_ids = np.append(input_ids, self.model_eos_token)
+
+        ans = {"input_ids": input_ids, "length": len(input_ids)}
+        # add the requested obs attributes
+        for attr in self.obs_column_names:
+            if attr != "soma_joinid":
+                ans[attr] = self.obs_df.at[cell_joinid, attr]
+            else:
+                ans["soma_joinid"] = cell_joinid
+        return ans

--- a/tools/models/geneformer/helpers/geneformer_tokenizer.py
+++ b/tools/models/geneformer/helpers/geneformer_tokenizer.py
@@ -17,9 +17,6 @@ class GeneformerTokenizer(CellDatasetBuilder):
     This class requires the Geneformer package to be installed separately with:
     `pip install transformers[torch]<4.50 git+https://huggingface.co/ctheodoris/Geneformer@ebc1e096`
 
-    **DEPRECATION NOTICE:** this is planned for removal from the cellxgene_census API and
-    migrated into git:cellxgene-census/tools/models/geneformer.
-
     Example usage:
 
     ```

--- a/tools/models/geneformer/prepare-census-geneformer-dataset.py
+++ b/tools/models/geneformer/prepare-census-geneformer-dataset.py
@@ -17,7 +17,7 @@ sys.path.insert(0, os.path.dirname(__file__))  # to find ./helpers
 import cellxgene_census
 import numpy as np
 import tiledbsoma
-from cellxgene_census.experimental.ml.huggingface import GeneformerTokenizer
+from helpers import GeneformerTokenizer
 
 # TODO: switch to https://github.com/chanzuckerberg/cellxgene-ontology-guide
 from helpers.ontology_mapper import CellSubclassMapper

--- a/tools/models/geneformer/test_GeneformerTokenizer.py
+++ b/tools/models/geneformer/test_GeneformerTokenizer.py
@@ -1,3 +1,4 @@
+# Unit tests for helpers.geneformer_tokenizer; these are executed in the Docker build.
 import os
 import sys
 

--- a/tools/models/geneformer/test_GeneformerTokenizer.py
+++ b/tools/models/geneformer/test_GeneformerTokenizer.py
@@ -1,0 +1,99 @@
+import os
+import sys
+
+import cellxgene_census
+import datasets
+import tiledbsoma
+from py.path import local as Path
+from scipy.stats import spearmanr
+
+sys.path.insert(0, os.path.dirname(__file__))  # to find ./helpers
+from geneformer import TranscriptomeTokenizer
+from helpers import GeneformerTokenizer
+
+CENSUS_VERSION_FOR_GENEFORMER_TESTS = "2023-12-15"
+
+
+def test_GeneformerTokenizer_correctness(tmpdir: Path) -> None:
+    """Test that GeneformerTokenizer produces the same token sequences as the original
+    geneformer.TranscriptomeTokenizer (modulo a small tolerance on Spearman rank correlation).
+    """
+    # causes deterministic selection of roughly 1,000 cells:
+    MODULUS = 32768
+    # minimum Spearman rank correlation to consider token sequences effectively identical; this
+    # allows for rare, slight differences in token sequences possibly arising from unstable sorting
+    # and/or minor numerical precision differences in lowly-expressed genes.
+    RHO_THRESHOLD = 0.99
+    # notwithstanding RHO_THRESHOLD, we'll check that almost all token sequences are -exactly-
+    # identical.
+    EXACT_THRESHOLD = 0.98
+
+    with cellxgene_census.open_soma(census_version=CENSUS_VERSION_FOR_GENEFORMER_TESTS) as census:
+        human = census["census_data"]["homo_sapiens"]
+        # read obs dataframe to get soma_joinids of all primary cells
+        obs_df = (
+            human.obs.read(column_names=["soma_joinid"], value_filter="is_primary_data == True").concat().to_pandas()
+        )
+        # select those with soma_joinid == 0 (mod MODULUS)
+        cell_ids = [it for it in obs_df["soma_joinid"].tolist() if it % MODULUS == 0]
+
+        # run our GeneformerTokenizer on them
+        with GeneformerTokenizer(
+            human,
+            obs_query=tiledbsoma.AxisQuery(coords=(cell_ids,)),
+        ) as tokenizer:
+            test_tokens = [it["input_ids"] for it in tokenizer.build()]
+
+        # write h5ad for use with geneformer.TranscriptomeTokenizer
+        ad = cellxgene_census.get_anndata(
+            census,
+            "homo_sapiens",
+            X_name="raw",
+            obs_coords=cell_ids,
+            column_names=tiledbsoma.AxisColumnNames(var=["feature_id"]),
+        )
+        ad.var.rename(columns={"feature_id": "ensembl_id"}, inplace=True)
+        ad.obs["n_counts"] = ad.X.sum(axis=1)
+        h5ad_dir = tmpdir.join("h5ad")
+        h5ad_dir.mkdir()
+        ad.write_h5ad(h5ad_dir.join("tokenizeme.h5ad"))
+        # run geneformer.TranscriptomeTokenizer to get "true" tokenizations
+        # see: https://huggingface.co/ctheodoris/Geneformer/blob/main/geneformer/tokenizer.py
+        TranscriptomeTokenizer({}).tokenize_data(h5ad_dir, str(tmpdir), "tk", file_format="h5ad")
+        true_tokens = [it["input_ids"] for it in datasets.load_from_disk(tmpdir.join("tk.dataset"))]
+
+        # check GeneformerTokenizer sequences against geneformer.TranscriptomeTokenizer's
+        assert len(test_tokens) == len(cell_ids)
+        assert len(true_tokens) == len(cell_ids)
+        identical = 0
+        for i, cell_id in enumerate(cell_ids):
+            if len(test_tokens[i]) != len(true_tokens[i]):
+                assert test_tokens[i] == true_tokens[i]  # to show diff
+            rho, _ = spearmanr(test_tokens[i], true_tokens[i])
+            if rho < RHO_THRESHOLD:
+                # token sequences are too dissimilar; assert exact identity so that pytest -vv will
+                # show the complete diff:
+                assert (
+                    test_tokens[i] == true_tokens[i]
+                ), f"Discrepant token sequences for cell soma_joinid={cell_id}; Spearman rho={rho}"
+            elif test_tokens[i] == true_tokens[i]:
+                identical += 1
+        assert identical / len(cell_ids) >= EXACT_THRESHOLD
+
+
+def test_GeneformerTokenizer_docstring_example() -> None:
+    with cellxgene_census.open_soma(census_version=CENSUS_VERSION_FOR_GENEFORMER_TESTS) as census:
+        with GeneformerTokenizer(
+            census["census_data"]["homo_sapiens"],
+            # set obs_query to define some subset of Census cells:
+            obs_query=tiledbsoma.AxisQuery(value_filter="is_primary_data == True and tissue_general == 'tongue'"),
+            obs_attributes=(
+                "soma_joinid",
+                "cell_type_ontology_term_id",
+            ),
+            max_input_tokens=2048,
+            special_token=False,
+        ) as tokenizer:
+            dataset = tokenizer.build()
+            assert len(dataset) == 15020
+            assert sum(it.length for it in dataset.to_pandas().itertuples()) == 27793772


### PR DESCRIPTION
Copying GeneformerTokenizer (and CellDatasetBuilder) to `tools/models/geneformer`, where it will live after eventual removal from the `cellxgene_census.experimental` API. Updates the Dockerfile there to run the GeneformerTokenizer unit tests to exercise the local installation.