### PR TITLE
[python] builder: dedup organisms table

### DIFF
--- a/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/census_summary.py
+++ b/tools/cellxgene_census_builder/src/cellxgene_census_builder/build_soma/census_summary.py
@@ -53,6 +53,9 @@ def create_census_info_organisms(
             for eb in experiment_builders
         ]
     )
+    # Deduplicate multiple ExperimentSpecifications that refer to the same
+    # organism (e.g., spatial vs non-spatial experiments).
+    df = df.drop_duplicates(ignore_index=True)
     df["soma_joinid"] = range(len(df))
     with info_collection.add_new_dataframe(
         CENSUS_INFO_ORGANISMS_NAME,


### PR DESCRIPTION
This is a minimal diff to drop the duplicate rows from the `census["census_info"]["organisms"]` table arising from the builder's distinct spatial & non-spatial ExperimentSpecs for human and mouse.

Rather than the simple deduplication, perhaps it'd be useful to add a `modality` or `[modalities]` column or something like that, but that would be a schema change; we can discuss that or perhaps just leave behind a ticket.