### PR TITLE
chore: migrate runner label from xl-amd64-privileged to lg-amd64-privileged

### DIFF
--- a/.github/workflows/py-unittests.yml
+++ b/.github/workflows/py-unittests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false  # Don't stop the workflow if one of the jobs fails
       matrix:
-        os: [xl-amd64-privileged, macos-latest]
+        os: [lg-amd64-privileged, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         exclude:
           - os: macos-latest
@@ -39,7 +39,7 @@ jobs:
             api/**/pyproject.toml
             api/**/requirements*.txt
       - name: Install git-lfs (Linux)
-        if: matrix.os == 'xl-amd64-privileged'
+        if: matrix.os == 'lg-amd64-privileged'
         run: |
           sudo apt-get update
           sudo apt-get install git-lfs


### PR DESCRIPTION
The `xl-amd64-privileged` runner has been resized to 16 CPU / 64Gi (from 8 CPU / 48Gi). The `lg-amd64-privileged` runner (8 CPU / 32Gi) is the roughly equivalent replacement for workloads that don't need the larger size.